### PR TITLE
fix(ngdoc/members): render member docs correctly

### DIFF
--- a/ngdoc/spec/tag-defs/tags.spec.js
+++ b/ngdoc/spec/tag-defs/tags.spec.js
@@ -99,6 +99,18 @@ describe('tag definitions', function() {
         expect(tagDef.defaultFn(doc)).toEqual('module:ngRoute.service:$http');
       });
 
+      it("should extract the container and member from the name if it is a memberOf type", function() {
+        doc.docType = 'method';
+        doc.name = '$http#get';
+        doc.area = 'api';
+        doc.module = 'ng';
+
+        expect(tagDef.defaultFn(doc)).toEqual('$http#get');
+        expect(doc.name).toEqual('get');
+        expect(doc.memberof).toEqual('$http');
+        expect(doc.isMember).toEqual(true);
+      });
+
     });
   });
 

--- a/ngdoc/tag-defs/index.js
+++ b/ngdoc/tag-defs/index.js
@@ -54,7 +54,7 @@ module.exports = [
   {
     name: 'id',
     defaultFn: function(doc) {
-      var partialFolder = 'partials';
+      var parts, partialFolder = 'partials';
       if ( doc.area === 'api' && doc.docType !== 'overview' ) {
         if ( doc.docType === 'module' ) {
           doc.id = _.template('module:${name}', doc);
@@ -69,7 +69,9 @@ module.exports = [
         } else {
           doc.id = doc.name;
           doc.isMember = true;
-          doc.memberof = doc.id.split('#')[0];
+          parts = doc.id.split('#');
+          doc.memberof = parts[0];
+          doc.name = parts[1];
           // This is a member of another doc so it doesn't need an output path
         }
       } else {
@@ -78,7 +80,7 @@ module.exports = [
         if ( doc.docType === 'error' ) {
           // Parse out the error info from the id
           doc.id = doc.name;
-          var parts = doc.id.split(':');
+          parts = doc.id.split(':');
           doc.namespace = parts[0];
           doc.name = parts[1];
         }

--- a/ngdoc/templates/lib/events.template.html
+++ b/ngdoc/templates/lib/events.template.html
@@ -2,7 +2,7 @@
 <h2>Events</h2>
 <ul class="events">
   {%- for event in doc.events %}
-  <li>
+  <li id="{$ event.name $}">
     <h3>{$ event.name $}</h3>
     <div>{$ event.description | marked $}</div>
     {%- if event.eventType == 'listen' %}

--- a/ngdoc/templates/lib/methods.template.html
+++ b/ngdoc/templates/lib/methods.template.html
@@ -2,7 +2,7 @@
 <h2>Methods</h2>
 <ul class="methods">
   {%- for method in doc.methods %}
-  <li>
+  <li id="{$ method.name $}">
     <h3>{$ functionSyntax(method) $}</h3>
     <div>{$ method.description | marked $}</div>
 

--- a/ngdoc/templates/lib/properties.template.html
+++ b/ngdoc/templates/lib/properties.template.html
@@ -1,0 +1,11 @@
+{%- if doc.properties %}
+<h2>Properties</h2>
+<ul class="properties">
+  {%- for property in doc.properties %}
+  <li id="{$ property.name $}">
+    <h3>{$ property.name | code $}</h3>
+    <div>{$ property.description | marked $}</div>
+  </li>
+  {% endfor -%}
+</ul>
+{%- endif -%}


### PR DESCRIPTION
Ensure that members have HTML ids set on their elements for linking to.
Actually implement the missing template for properties.
Extract the name from the id of the member doc.

Closes #2
