### PR TITLE
fix(ngdoc/templates) : Improve the buttons and this icons

### DIFF
--- a/ngdoc/templates/api/api.template.html
+++ b/ngdoc/templates/api/api.template.html
@@ -2,8 +2,8 @@
 
 {% block content %}
 
-<a href='http://github.com/{$ git.info.owner $}/{$ git.info.repo $}/tree/{$ git.version.tag or 'master' $}/{$ doc.relativePath $}#L{$ doc.startingLine $}' class='view-source pull-right'>
-  <i class="icon-zoom-in">&nbsp;</i>View Source
+<a href='http://github.com/{$ git.info.owner $}/{$ git.info.repo $}/tree/{$ git.version.tag or 'master' $}/{$ doc.relativePath $}#L{$ doc.startingLine $}' class='view-source pull-right btn btn-primary'>
+  <i class="glyphicon glyphicon-zoom-in">&nbsp;</i>View Source
 </a>
 
 {% block header %}

--- a/ngdoc/templates/base.template.html
+++ b/ngdoc/templates/base.template.html
@@ -1,4 +1,4 @@
-<a href='http://github.com/angular/angular.js/edit/master/{$ doc.relativePath $}' class='improve-docs'><i class="icon-edit">&nbsp;</i>Improve this doc</a>
+<a href='http://github.com/angular/angular.js/edit/master/{$ doc.relativePath $}' class='improve-docs btn btn-primary'><i class="glyphicon glyphicon-edit">&nbsp;</i>Improve this doc</a>
 
 {% block content %}
 {% endblock %}


### PR DESCRIPTION
Since version 3 of bootstrap, use glyphicon for icons.
And to have the same display as buttons tutorial (Next, Live Demo ...)
