### PR TITLE
fix(directive-template): improve block "Directive Info"

### DIFF
--- a/ngdoc/templates/api/directive.template.html
+++ b/ngdoc/templates/api/directive.template.html
@@ -2,11 +2,13 @@
 {% extends "api/api.template.html" %}
 
 {% block additional %}
+  {% if doc.scope or doc.priority %}
   <h2>Directive Info</h2>
   <ul>
     {% if doc.scope %}<li>This directive creates new scope.</li>{% endif %}
-    <li>This directive executes at priority level {$ doc.priority $}.</li>
+    {% if doc.priority %}<li>This directive executes at priority level {$ doc.priority $}.</li>{% endif %}
   </ul>
+  {% endif %}
 
   {% block usage %}
   <h2 id="usage">Usage</h2>


### PR DESCRIPTION
if `priority` is undefined, doesn't display "priority level" in the block.

if `priority` AND `scope` are undefined, doesn't display the block
