### PR TITLE
Update jsdoc.js

### DIFF
--- a/jsdoc/extractors/jsdoc.js
+++ b/jsdoc/extractors/jsdoc.js
@@ -1,7 +1,7 @@
 var _ = require('lodash');
 var jsParser = require('esprima');
 var walk = require('../lib/walk');
-var LEADING_STAR = /^\*[^\S\n]?/gm;
+var LEADING_STAR = /[\f\r\t\v\u00A0\u2028\u2029]*^\*[^\S\n]?/gm;
 
 module.exports = {
   pattern: /\.js$/,

--- a/jsdoc/spec/extractors/jsdoc.spec.js
+++ b/jsdoc/spec/extractors/jsdoc.spec.js
@@ -31,5 +31,10 @@ describe("js doc extractor", function() {
       expect(docs[1].code.node.type).toEqual('ExpressionStatement');
       expect(docs[2].code.node.type).toEqual('ReturnStatement');
     });
+
+    it("should not remove windows new line characters when stripping stars from comments", function() {
+        var docs = extractor.processFile('some/file.js', '/** Some jsdoc comment\r\n* over multiple\r\n* lines\r\n**/');
+        expect(docs[0].content).toEqual('Some jsdoc comment\r\nover multiple\r\nlines');
+    });
   });
 });


### PR DESCRIPTION
Do not remove the leading space before comment stars, the parser has already done this so it causes issues using windows line endings
