### PR TITLE
fix(link inline tag): parse whitespace in link's title

### DIFF
--- a/ngdoc/inline-tag-defs/link.js
+++ b/ngdoc/inline-tag-defs/link.js
@@ -1,4 +1,4 @@
-var INLINE_LINK = /(\S+)(?:\s+(.+))?/;
+var INLINE_LINK = /(\S+)(?:\s+([\s\S]+))?/;
 
 module.exports = {
   name: 'link',

--- a/ngdoc/spec/inline-tag-defs/link.spec.js
+++ b/ngdoc/spec/inline-tag-defs/link.spec.js
@@ -25,6 +25,7 @@ describe("links inline tag handler", function() {
       file: 'some/file.js',
       startingLine: 200,
       renderedContent: "Some text with a {@link some/url link} to somewhere\n" +
+                       "Another text with a {@link another/url that spans\n two lines}\n" +
                        "Some example with a code link: {@link module:ngOther.directive:ngDirective}\n" +
                        "A link to reachable code: {@link ngInclude}"
     };
@@ -41,6 +42,10 @@ describe("links inline tag handler", function() {
 
   it("should convert urls to HTML anchors", function() {
     expect(linkHandler(doc, 'link', 'some/url link')).toEqual('<a href="some/url">link</a>');
+  });
+
+  it("should parse empty space within a link's title", function() {
+    expect(linkHandler(doc, 'link', 'another/url link that spans\n two lines')).toEqual('<a href="another/url">link that spans\n two lines</a>');
   });
 
   it("should convert code links to anchors with formatted code", function() {


### PR DESCRIPTION
Fix an issue where new lines within a link's tag title caused only part of the title to be anchored.

Closes #35
