### PR TITLE
Turn all partialName maps into arrays

### DIFF
--- a/ngdoc/utils/partial-names.js
+++ b/ngdoc/utils/partial-names.js
@@ -100,26 +100,13 @@ PartialNames.prototype.addDoc = function(doc) {
   // This map will be used to match relative links later on
   _.forEach(doc.partialNames, function(partialName) {
 
-    // Try to get a list of docs that match this partialName
-    var matchedDocs = map[partialName];
-
-    if ( !matchedDocs ) {
-      // This partial name is not yet used - add it to the map
-      map[partialName] = doc;
-
-    } else {
-
-      if ( _.isArray(matchedDocs) ) {
-        // There are already more than one docs associated with this partialName - add this one too
-        matchedDocs.push(doc);
-      } else {
-        // There is already one doc associated with this partialName - convert the entry to an array
-        matchedDocs = [matchedDocs, doc];
-      }
-
-      // Add the array of matchedDocs back to the map
-      map[partialName] = matchedDocs;
+    if ( !map[partialName] ) {
+      // This partial name is not yet used - create a new map
+      map[partialName] = [];
     }
+
+    // Add doc to the partial list
+    map[partialName].push(doc);
   });
 
 };


### PR DESCRIPTION
In my documentation I want to extend the partial maps.
It would be way easier if those maps would always be arrays for me.

Another advantage is the reduced code complexity in partial-names.js
