### PR TITLE
Allow to exclude files from parsing

### DIFF
--- a/base/processors/read-files.js
+++ b/base/processors/read-files.js
@@ -49,6 +49,11 @@ module.exports = {
 
       files = glob.sync(fileInfo.pattern, { cwd: fileInfo.basePath });
 
+      // Allow to exclude files using a filter
+      if ( _.isFunction(fileInfo.filter) ) {
+        files = files.filter(fileInfo.filter);
+      }
+
       log.debug('Found ' + files.length + ' files');
 
       var docPromises = [];


### PR DESCRIPTION
Right now the only way to specify which files should be parsed is setting a mini match expression.
That's fine in most cases however it doesn't allow to excludes from being parsed.

Therefore my pull request changes the current `source.files` schema `'{ pattern: "...", basePath: "..." }` and
adds an optional filter function attribute: `'{ pattern: "...", basePath: "...", filter: ... }`.
