### PR TITLE
Blind fix: default param values

### DIFF
--- a/ngdoc/templates/lib/macros.html
+++ b/ngdoc/templates/lib/macros.html
@@ -24,7 +24,7 @@
       </td>
       <td>
         {$ param.description | marked $}
-        {% if param.default %}<p><em>(default: {$ param.default $})</em></p>{% endif %}
+        {% if param.defaultValue %}<p><em>(default: {$ param.defaultValue $})</em></p>{% endif %}
       </td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
Default param values are absent from the Angular docs now, so I did this quick blind fix of what appeared like the cause of the problem without any testing or even understanding the code. Please ignore this PR if I'm wrong on this thing.
