### PR TITLE
fix(base/resolveUrl): fix for Windows with base

### DIFF
--- a/base/services/resolveUrl.js
+++ b/base/services/resolveUrl.js
@@ -21,7 +21,7 @@ module.exports = function resolveUrl() {
     if ( base && newPath.charAt(0) !== '/' ) {
       // Resolve against the base url if there is a base and the new path is not absolute
       newPath = path.resolve(base, newPath)
-      newPath = newPath.substr(newPath.indexOf(base) + 1);
+      newPath = newPath.substr(newPath.indexOf(base) + base.length);
     } else {
       // Otherwise resolve against the current path
       newPath = url.resolve(currentPath || '', newPath);


### PR DESCRIPTION
When passing a base of '/' to the checkAnchorLinksProcessor on Windows, resolveUrl would fail by creating a URL that started with `:/`. This is because `path.resolve` was returning a URL that started with `c:/`. Removing the first character is not enough. This code fixes that.
