### PR TITLE
fix(base/resolveUrl): fix for Windows with base

### DIFF
--- a/base/services/resolveUrl.js
+++ b/base/services/resolveUrl.js
@@ -20,7 +20,8 @@ module.exports = function resolveUrl() {
 
     if ( base && newPath.charAt(0) !== '/' ) {
       // Resolve against the base url if there is a base and the new path is not absolute
-      newPath = path.resolve(base, newPath).substr(1);
+      newPath = path.resolve(base, newPath)
+      newPath = newPath.substr(newPath.indexOf('/') + 1);
     } else {
       // Otherwise resolve against the current path
       newPath = url.resolve(currentPath || '', newPath);


### PR DESCRIPTION
fix to no longer assume that path.resolve returns a string starting
with ‘/‘

When passing a base of '/' to the checkAnchorLinksProcessor on Windows, resolveUrl would fail by creating a URL that started with :/. This is because path.resolve was returning a URL that started with c:/. Removing the first character is not enough. This code fixes that.
