### PR TITLE
Throw an error if a module has not been documented.

### DIFF
--- a/ngdoc/processors/moduleDocs.js
+++ b/ngdoc/processors/moduleDocs.js
@@ -48,7 +48,11 @@ module.exports = function moduleDocsProcessor(log, aliasMap, moduleMap, createDo
 
           if ( matchingModules.length === 1 ) {
             var module = matchingModules[0];
-            module.components.push(doc);
+            if (module.components) {
+              module.components.push(doc);
+            } else {
+              throw new Error("Module '"+module.name+"' is not documented.");
+            }
             doc.moduleDoc = module;
           } else if ( matchingModules.length > 1 ) {
             var error = createDocMessage('Ambiguous module reference: "' + doc.module + '"', doc);


### PR DESCRIPTION
If a module has not been documented, the following error is returned, but it does not provide any indication on how to fix the problem:

```
error:   TypeError: Cannot call method 'push' of undefined
    at C:\Data\test\grunt-udoc-sample\node_modules\dgeni-packages\ngdoc\processors\moduleDocs.js:52:
31
    at Function.forEach (C:\Data\test\grunt-udoc-sample\node_modules\lodash\dist\lodash.js:3297:15)
    at Object.$process (C:\Data\test\grunt-udoc-sample\node_modules\dgeni-packages\ngdoc\processors\
moduleDocs.js:40:9)
    at Q.then.catch.error.message (C:\Data\test\grunt-udoc-sample\node_modules\dgeni\lib\Dgeni.js:20
2:28)
    at _fulfilled (C:\Data\test\grunt-udoc-sample\node_modules\dgeni\node_modules\q\q.js:798:54)
    at self.promiseDispatch.done (C:\Data\test\grunt-udoc-sample\node_modules\dgeni\node_modules\q\q
.js:827:30)
    at Promise.promise.promiseDispatch (C:\Data\test\grunt-udoc-sample\node_modules\dgeni\node_modul
es\q\q.js:760:13)
    at C:\Data\test\grunt-udoc-sample\node_modules\dgeni\node_modules\q\q.js:821:14
    at flush (C:\Data\test\grunt-udoc-sample\node_modules\dgeni\node_modules\q\q.js:108:17)
    at process._tickCallback (node.js:415:13)
error:   Error processing docs:
```

It is OK to throw an error, but at least an indication of the undocumented module should be provided (see attached pull request).
