### PR TITLE
fix(ngdoc/moduleDocs): throw an error if a module is improperly tagged

### DIFF
--- a/ngdoc/processors/moduleDocs.js
+++ b/ngdoc/processors/moduleDocs.js
@@ -51,7 +51,7 @@ module.exports = function moduleDocsProcessor(log, aliasMap, moduleMap, createDo
             if (module.docType === 'module') {
               module.components.push(doc);
             } else {
-              throw new Error('Entity "'+module.name+'" must be documented as "module", not as "'+module.docType+'".');
+              throw new Error(createDocMessage('"' + module.name + '" is not a module. It is documented as "' + module.docType + '". Either the module is incorrectly typed or the module reference is invalid', doc));
             }
             doc.moduleDoc = module;
           } else if ( matchingModules.length > 1 ) {

--- a/ngdoc/processors/moduleDocs.spec.js
+++ b/ngdoc/processors/moduleDocs.spec.js
@@ -101,7 +101,8 @@ describe("moduleDocsProcessor", function() {
 
     expect(function() {
       processor.$process([doc1, doc2, doc3]);
-    }).toThrowError('Entity "mod2" must be documented as "module", not as "object".');
+    }).toThrowError('"mod2" is not a module. It is documented as "object". Either the module is incorrectly typed or the module reference is invalid - doc "mod2.service2" (service) ');
+
   });
 
 });


### PR DESCRIPTION
Dgeni should throw a meaningful error if a module is improperly tagged as another entity (e.g. object, function, etc.).

At present, if a module has been improperly tagged as "object" or another entity, the following error is returned, but it does not provide any indication on how to fix the problem:

```
error:   TypeError: Cannot call method 'push' of undefined
    at C:\Data\test\grunt-udoc-sample\node_modules\dgeni-packages\ngdoc\processors\moduleDocs.js:52:31
    at Function.forEach (C:\Data\test\grunt-udoc-sample\node_modules\lodash\dist\lodash.js:3297:15)
    at Object.$process (C:\Data\test\grunt-udoc-sample\node_modules\dgeni-packages\ngdoc\processors\moduleDocs.js:40:9)
    at Q.then.catch.error.message (C:\Data\test\grunt-udoc-sample\node_modules\dgeni\lib\Dgeni.js:202:28)
    at _fulfilled (C:\Data\test\grunt-udoc-sample\node_modules\dgeni\node_modules\q\q.js:798:54)
    at self.promiseDispatch.done (C:\Data\test\grunt-udoc-sample\node_modules\dgeni\node_modules\q\q.js:827:30)
    at Promise.promise.promiseDispatch (C:\Data\test\grunt-udoc-sample\node_modules\dgeni\node_modules\q\q.js:760:13)
    at C:\Data\test\grunt-udoc-sample\node_modules\dgeni\node_modules\q\q.js:821:14
    at flush (C:\Data\test\grunt-udoc-sample\node_modules\dgeni\node_modules\q\q.js:108:17)
    at process._tickCallback (node.js:415:13)
error:   Error processing docs:
```
