### PR TITLE
Support inline-tag in firstLine filter.

### DIFF
--- a/nunjucks/rendering/filters/first-line.js
+++ b/nunjucks/rendering/filters/first-line.js
@@ -6,16 +6,9 @@ module.exports = {
   name: 'firstLine',
   process: function(str) {
     if (!str) return str;
-
-    var firstLine = str
-      .split("\n")[0];
-    if (firstLine.split("{@").length > firstLine.split("}").length) {
-      var match = str.match(/\n(.*?\})/);
-      if (match) {
-        firstLine = firstLine + ' ' + match[1];
-      }
-    }
-
-    return firstLine;
+    
+    return str.match(/([^$]*\{@[^}]+\})|.*(\n|$)/)[0]
+              .replace("\n", " ")
+              .trim();
   }
 };

--- a/nunjucks/rendering/filters/first-line.spec.js
+++ b/nunjucks/rendering/filters/first-line.spec.js
@@ -4,6 +4,9 @@ describe("firstLine filter", function() {
   it("should have the name 'firstLine'", function() {
     expect(filter.name).toEqual('firstLine');
   });
+  it("should return all at one line", function() {
+    expect(filter.process('this is a line')).toEqual('this is a line');
+  });
   it("should return the content up to the first newline", function() {
     expect(filter.process('this is a line\nthis is another line')).toEqual('this is a line');
   });


### PR DESCRIPTION
```
{$ component.description | firstLine $}
```

I create dgeni template. but happen warning.

```
warn:    No handler provided for inline tag "{@link</p>  |
| $rootScope | <p>Every application has a single root {@link ng.$rootScope.Scope scope}" - doc "module:ng.service" (componentGroup) 
```

firstLine should return the contents until inline-tag closes.
