### PR TITLE
fix(checkAnchorLinks): ignore "absolute" links (with specific schemes)

### DIFF
--- a/base/processors/checkAnchorLinks.js
+++ b/base/processors/checkAnchorLinks.js
@@ -84,6 +84,9 @@ module.exports = function checkAnchorLinksProcessor(log, resolveUrl, extractLink
           })
 
           .forEach(function(link) {
+            // Ignore absolute links with specific schemes...
+            if (/^((https?)|(ftps?):\/\/)|((chrome)|(about):(\/\/)?)/.test(link)) return;
+
             var normalizedLink = path.join(webRoot, resolveUrl(linkInfo.path, link, base));
             if ( !_.any(pathVariants, function(pathVariant) {
               return allValidReferences[normalizedLink + pathVariant];

--- a/base/processors/checkAnchorLinks.spec.js
+++ b/base/processors/checkAnchorLinks.spec.js
@@ -106,4 +106,36 @@ describe("checkAnchorLinks", function() {
     ]);
     expect(mockLog.warn).not.toHaveBeenCalled();
   });
+
+  it("should skip links with `chrome` scheme", function() {
+    processor.$process([
+      { renderedContent: '<a href="chrome:accessibility">accessibility</a>' },
+      { renderedContent: '<a href="chrome://accessibility">accessibility</a>' },
+    ]);
+    expect(mockLog.warn).not.toHaveBeenCalled();
+  });
+
+  it("should skip links with `about` scheme", function() {
+    processor.$process([
+      { renderedContent: '<a href="about:blank">blank</a>' },
+      { renderedContent: '<a href="about://config">config</a>' },
+    ]);
+    expect(mockLog.warn).not.toHaveBeenCalled();
+  });
+
+  it("should skip links with `http/https` scheme", function() {
+    processor.$process([
+      { renderedContent: '<a href="http://www.google.com">goog</a>' },
+      { renderedContent: '<a href="https://www.facebook.com">fcbk</a>' },
+    ]);
+    expect(mockLog.warn).not.toHaveBeenCalled();
+  });
+
+  it("should skip links with `ftp/ftps` scheme", function() {
+    processor.$process([
+      { renderedContent: '<a href="ftp://my.house.com/readme.txt">public</a>' },
+      { renderedContent: '<a href="ftps://my.secure.house.com/secrets.txt">SCRT</a>' },
+    ]);
+    expect(mockLog.warn).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
This will fix the "dangling link" in angular.js builds for chrome://accessibility