### PR TITLE
fix(checkAnchorLinks): add decodeURIComponent call when checking for …

### DIFF
--- a/base/processors/checkAnchorLinks.js
+++ b/base/processors/checkAnchorLinks.js
@@ -86,7 +86,7 @@ module.exports = function checkAnchorLinksProcessor(log, resolveUrl, extractLink
           .forEach(function(link) {
             var normalizedLink = path.join(webRoot, resolveUrl(linkInfo.path, link, base));
             if ( !_.any(pathVariants, function(pathVariant) {
-              return allValidReferences[normalizedLink + pathVariant];
+              return allValidReferences[decodeURIComponent(normalizedLink + pathVariant)];
             }) ) {
               unmatchedLinks.push(link);
             }

--- a/base/processors/checkAnchorLinks.spec.js
+++ b/base/processors/checkAnchorLinks.spec.js
@@ -36,6 +36,14 @@ describe("checkAnchorLinks", function() {
     expect(mockLog.warn).not.toHaveBeenCalled();
   });
 
+  it('should match links who are prone to uri encoding', function() {
+    processor.$process([
+      { renderedContent: '<a href="Foo extends Bar"></a>', outputPath: 'doc/path.html', path: 'doc/path' },
+      { renderedContent: 'CONTENT OF FOO', outputPath: 'doc/Foo extends Bar.html', path: 'doc/Foo extends Bar' }
+    ])
+    expect(mockLog.warn).not.toHaveBeenCalled();
+  });
+
   it("should not warn if the link matches a path after it has been modified with a path variant", function() {
     processor.$process([
       { renderedContent: '<a href="/foo"></a>', outputPath: 'doc/path.html', path: 'doc/path' },


### PR DESCRIPTION
…dangling links

Fixes issue when links with spaces in them were being encoded by node's url service,
but keys being checked against were decoded. Related to angular/angular#2452