### PR TITLE
fix(ngdoc/templates/lib/events): add params section to event template 

### DIFF
--- a/ngdoc/templates/lib/events.template.html
+++ b/ngdoc/templates/lib/events.template.html
@@ -19,6 +19,12 @@
       <div class="target">{$ event.eventTarget $}</div>
     </div>
     {% endif -%}
+    {%- if event.params %}
+    <section class="api-section">
+      <h3>Parameters</h3>
+      {$ paramTable(event.params) $}
+    </section>
+    {%- endif -%}
   </li>
   {% endfor -%}
 </ul>


### PR DESCRIPTION
This fixes https://github.com/angular/angular.js/issues/11418