### PR TITLE
Auto-generate docs that explain Dgeni's pipeline

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ node_modules
 .agignore
 
 coverage
+
+.tmp

--- a/base/index.js
+++ b/base/index.js
@@ -1,6 +1,10 @@
 var Package = require('dgeni').Package;
 
 // Define the `base` package
+/**
+ * @dgPackage base
+ * @description Defines minimal set of processors to get started with Dgeni
+ */
 module.exports = new Package('base')
 
 // A set of pseudo processors that act as markers to help position real processors at the right

--- a/base/processors/read-files.js
+++ b/base/processors/read-files.js
@@ -7,7 +7,7 @@ var Minimatch = require("minimatch").Minimatch;
 var StringMap = require('stringmap');
 
 /**
- * @dgPackage readFilesProcessor
+ * @dgProcessor readFilesProcessor
  *
  * @description Read documents from files and add them to the docs collection
  *

--- a/dgeni/index.js
+++ b/dgeni/index.js
@@ -1,5 +1,9 @@
 var Package = require('dgeni').Package;
 
+/**
+ * @dgPackage dgeni
+ * @description Support for documenting Dgeni packages (incomplete)
+ */
 module.exports = new Package('dgeni', ['jsdoc'])
 
 .config(function(parseTagsProcessor, getInjectables) {

--- a/docs/.jscsrc
+++ b/docs/.jscsrc
@@ -1,0 +1,65 @@
+{
+    "disallowSpacesInNamedFunctionExpression": {
+        "beforeOpeningRoundBrace": true
+    },
+    "requireSpacesInAnonymousFunctionExpression": {
+        "beforeOpeningRoundBrace": true,
+        "beforeOpeningCurlyBrace": true
+    },
+    "disallowSpacesInFunctionDeclaration": {
+        "beforeOpeningRoundBrace": true
+    },
+    "disallowEmptyBlocks": true,
+    "disallowSpacesInsideArrayBrackets": true,
+    "disallowSpacesInsideParentheses": true,
+    "disallowQuotedKeysInObjects": true,
+    "disallowSpaceAfterObjectKeys": true,
+    "disallowSpaceAfterPrefixUnaryOperators": true,
+    "disallowSpaceBeforePostfixUnaryOperators": true,
+    "disallowSpaceBeforeBinaryOperators": [
+        ","
+    ],
+    "disallowMixedSpacesAndTabs": true,
+    "disallowTrailingWhitespace": true,
+    "disallowTrailingComma": true,
+    "disallowYodaConditions": true,
+    "disallowKeywords": [ "with" ],
+    "disallowMultipleLineBreaks": true,
+    "disallowMultipleVarDecl": true,
+    "requireSpaceBeforeBlockStatements": true,
+    "requireParenthesesAroundIIFE": true,
+    "requireSpacesInConditionalExpression": true,
+    "requireBlocksOnNewline": 1,
+    "requireCommaBeforeLineBreak": true,
+    "requireSpaceBeforeBinaryOperators": true,
+    "requireSpaceAfterBinaryOperators": true,
+    "requireCamelCaseOrUpperCaseIdentifiers": true,
+    "requireLineFeedAtFileEnd": true,
+    "requireCapitalizedConstructors": true,
+    "requireDotNotation": true,
+    "requireSpacesInForStatement": true,
+    "requireSpaceBetweenArguments": true,
+    "requireCurlyBraces": [
+        "do"
+    ],
+    "requireSpaceAfterKeywords": [
+        "if",
+        "else",
+        "for",
+        "while",
+        "do",
+        "switch",
+        "case",
+        "return",
+        "try",
+        "catch",
+        "typeof"
+    ],
+    "requirePaddingNewLinesBeforeLineComments": {
+        "allExcept": "firstAfterCurly"
+    },
+    "requirePaddingNewLinesAfterBlocks": true,
+    "safeContextKeyword": "_this",
+    "validateQuoteMarks": "'",
+    "validateIndentation": 2
+}

--- a/docs/.jshintrc
+++ b/docs/.jshintrc
@@ -1,0 +1,61 @@
+{
+  /*
+   * ENVIRONMENTS
+   * =================
+   */
+
+  // Define globals exposed by modern browsers.
+  "browser": true,
+
+  // Define globals exposed by jQuery.
+  "jquery": true,
+
+  // Define globals exposed by Node.js.
+  "node": true,
+
+  "predef": [ "angular" ],
+
+  /*
+   * ENFORCING OPTIONS
+   * =================
+   */
+
+  // Force all variable names to use either camelCase style or UPPER_CASE
+  // with underscores.
+  "camelcase": true,
+
+  // Prohibit use of == and != in favor of === and !==.
+  "eqeqeq": true,
+
+  // Enforce tab width of 2 spaces.
+  "indent": 2,
+
+  // Prohibit use of a variable before it is defined.
+  "latedef": true,
+
+  // Enforce line length to 80 characters
+  "maxlen": 80,
+
+  // Require capitalized names for constructor functions.
+  "newcap": true,
+
+  // Enforce use of single quotation marks for strings.
+  "quotmark": "single",
+
+  // Enforce placing 'use strict' at the top function scope
+  "strict": true,
+
+  // Prohibit use of explicitly undeclared variables.
+  "undef": true,
+
+  // Warn when variables are defined but never used.
+  "unused": true,
+
+  /*
+   * RELAXING OPTIONS
+   * =================
+   */
+
+  // Suppress warnings about == null comparisons.
+  "eqnull": true
+}

--- a/docs/config/index.js
+++ b/docs/config/index.js
@@ -1,0 +1,67 @@
+// Canonical path provides a consistent path (i.e. always forward slashes) across different OSes
+var path = require('canonical-path');
+
+var projectPath = path.resolve(__dirname, '../..');
+var packagePath = __dirname;
+
+var Package = require('dgeni').Package;
+
+module.exports = new Package('dgeni-docs', [
+  require(path.resolve(projectPath, 'base')),
+  require(path.resolve(projectPath, 'jsdoc')),
+  require(path.resolve(projectPath, 'dgeni')),
+  require(path.resolve(projectPath, 'nunjucks'))
+])
+
+.processor(require('./processors/processorsData'))
+.processor(require('./processors/packagesData'))
+.processor(require('./processors/readDgeniDocs'))
+
+.config(function (readFilesProcessor, writeFilesProcessor) {
+  readFilesProcessor.basePath = projectPath;
+
+  readFilesProcessor.sourceFiles = [
+    {
+      include: [
+        '*/*.js',
+        '*/processors/**.js',
+        '*/services/**.js',
+        '*/file-readers/**.js',
+        '*/tag-defs/**.js',
+        '*/rendering/**.js'
+      ],
+      exclude: [
+        'docs',
+        '**/*.spec.js',
+        '**/*.template.js'
+      ],
+      basePath: projectPath },
+  ];
+
+  writeFilesProcessor.outputFolder = '.tmp/docs';
+})
+
+.config(function (templateFinder, templateEngine) {
+  templateFinder.templateFolders = [path.resolve(packagePath, 'template')];
+
+  // templateFinder.templatePatterns.unshift('${doc.template}');
+  templateFinder.templatePatterns.unshift('${doc.template}');
+  templateFinder.templatePatterns.unshift('${doc.docType}.template.html');
+  templateFinder.templatePatterns.push('common.template.html');
+
+  templateEngine.config.tags = {
+    variableStart: '{$',
+    variableEnd: '$}'
+  };
+})
+
+.config(function (computePathsProcessor, computeIdsProcessor) {
+  // Put jsdoc files in ./partials directory
+  computePathsProcessor.pathTemplates.push({
+    docTypes: ['js'],
+    pathTemplate: '${id}',
+    outputPathTemplate: 'partials/${path}.html'
+  });
+})
+
+;

--- a/docs/config/processors/packagesData.js
+++ b/docs/config/processors/packagesData.js
@@ -1,0 +1,31 @@
+
+var _ = require('lodash');
+var path = require('canonical-path');
+var inspect = require('eyes').inspector({ stream: null });
+
+module.exports = function packagesData() {
+  return {
+    $runAfter: ['adding-extra-docs'],
+    $runBefore: ['extra-docs-added'],
+    $process: function (docs) {
+      // Get packages
+      var packages = docs.filter(function (doc) {
+        return doc.hasOwnProperty('dgPackage') && (!doc.dgType || !doc.dgType === 'processor');
+      })
+      .map(function(p) {
+        p.name = p.dgPackage;
+        p.abbr = p.name.substr(0, 2).toUpperCase();
+        return _.pick(p, ['name', 'abbr', 'dgPackage', 'path', 'area', 'codeName', 'description', 'docType']);
+      });
+
+      docs.push({
+        docType: 'json',
+        id: 'packages-data',
+        name: 'PACKAGES',
+        template: 'constant-data.template.js',
+        outputPath: 'js/packages-data.js',
+        items: packages
+      });
+    }
+  };
+}

--- a/docs/config/processors/processorsData.js
+++ b/docs/config/processors/processorsData.js
@@ -1,0 +1,79 @@
+
+var _ = require('lodash');
+var path = require('canonical-path');
+var Dgeni = require('dgeni');
+// var inspect = require('eyes').inspector({ stream: null });
+
+var projectPath = path.resolve(__dirname, '../../..');
+var packagePath = __dirname;
+
+// Get the `sortByDependency` function from Dgeni. We'll use this to figure out processor order
+var sortByDependency = require(path.resolve(projectPath, 'node_modules/dgeni/lib/util/dependency-sort'));
+
+// Brind in the test package. All the various processors and placeholders will be in this
+var TestPackage = new Dgeni([ require('../testPackage') ]);
+
+module.exports = function processorsData() {
+  return {
+    $runAfter: ['adding-extra-docs'],
+    $runBefore: ['extra-docs-added'],
+    $process: function (docs) {
+      // Get processors
+      var processors = docs.filter(function (doc) {
+        // return hasTagPrefix(doc, 'dg');
+        return doc.hasOwnProperty('dgProcessor');
+      });
+
+      var processors = _.map(processors, function(p) {
+        p.readableName = p.codeName.replace(/Processor$/, '');
+        p.dgPackage = (p.fileInfo.projectRelativePath.split(/\//))[0];
+        p.dgType = 'processor';
+        return _.pick(p, ['name', 'readableName', 'dgPackage', 'path', 'area', 'codeName', 'description', 'docType']);
+      });
+
+      // Get packages from the Test Package
+      TestPackage.configureInjector();
+
+      // Sort the processors according to their $runAfter and $runBefore settings
+      var testPackageProcessors = sortByDependency(TestPackage.processors, '$runAfter', '$runBefore');
+
+      // Get the $package property and sort index for each processor
+      testPackageProcessors.forEach(function (testProc, i) {
+        // console.log(testProc.name, '-', testProc.$package);
+
+        var matchingProc = _.find(processors, { codeName: testProc.name });
+
+        // Processor is a placeholder; it has no $process method. Need to put in a record for it
+        if (!matchingProc) {
+          matchingProc = {
+            name: testProc.name,
+            readableName: testProc.name.replace(/Processor$/, ''),
+            dgPackage: testProc.$package
+          };
+          processors.push(matchingProc);
+        }
+        if (!testProc.$process) {
+          matchingProc.placeholder = true;
+        }
+
+        matchingProc.$package = testProc.$package;
+        matchingProc.index = i;
+      });
+
+      docs.push({
+        docType: 'json',
+        id: 'processors-data',
+        name: 'PROCESSORS',
+        template: 'constant-data.template.js',
+        outputPath: 'js/processors-data.js',
+        items: processors
+      });
+    }
+  };
+}
+
+function hasTagPrefix(doc, prefix) {
+  return doc.tags.tags.some(function (tag) {
+    return tag.tagName.indexOf(prefix) === 0;
+  });
+}

--- a/docs/config/processors/readDgeniDocs.js
+++ b/docs/config/processors/readDgeniDocs.js
@@ -1,0 +1,37 @@
+
+// TODO: remove eyes
+var eyes = require('eyes');
+var inspect = require('eyes').inspector({ stream: null });
+
+module.exports = function readDgeniDocs() {
+  return {
+    $runAfter: ['processorsData'],
+    $runBefore: ['extra-docs-added'],
+    $process: function (docs) {
+      var indexPage = {
+        docType: 'index',
+        template: 'index.template.html',
+        outputPath: 'index.html',
+        path: 'index.html'
+      };
+
+      indexPage.docs = docs.filter(function (doc) {
+        return hasTagPrefix(doc, 'dg');
+      });
+
+      docs.push(indexPage);
+
+      return docs.filter(function (doc) {
+        return (doc.docType === 'index' || doc.docType === 'json');
+      });
+    }
+  };
+}
+
+function hasTagPrefix(doc, prefix) {
+  if (!doc.tags || !doc.tags.tags) return false;
+
+  return doc.tags.tags.some(function (tag) {
+    return tag.tagName.indexOf(prefix) === 0;
+  });
+}

--- a/docs/config/template/common.template.html
+++ b/docs/config/template/common.template.html
@@ -1,0 +1,20 @@
+<h1>{$ doc.codeName $} ({$ doc.outputPath $})</h1>
+<p>{$ doc.description $}</p>
+
+{%- if doc.params %}
+<h2>Params</h2>
+<ul>
+{%- for param in doc.params %}
+  <li>
+    <strong>{$ param.name $}</strong> { {$ param.typeList $} } - {$ param.description $}
+  </li>
+{%- endfor %}
+</ul>
+{%- endif %}
+
+{%- if doc.returns %}
+<h2>Returns</h2>
+<p>
+  { {$ doc.returns.typeList $} } - {$ doc.returns.description $}
+</p>
+{%- endif %}

--- a/docs/config/template/constant-data.template.js
+++ b/docs/config/template/constant-data.template.js
@@ -1,0 +1,9 @@
+try {
+  angular.module('constants')
+}
+catch (e) {
+  angular.module('constants', []);
+}
+
+angular.module('constants')
+.constant('{$ doc.name $}', {$ doc.items | json $});

--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html ng-app="dgeniPipeline" ng-cloak>
+
+  <head>
+    <script data-require="jquery@*" data-semver="2.1.4" src="http://code.jquery.com/jquery-2.1.4.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/0.3.2/marked.js"></script>
+    <script data-require="angular.js@1.4.1" data-semver="1.4.1" src="https://code.angularjs.org/1.4.1/angular.js"></script>
+    <script data-require="angular.js@1.4.1" data-semver="1.4.1" src="https://code.angularjs.org/1.4.1/angular-sanitize.js"></script>
+    <script data-require="angular.js@1.4.1" data-semver="1.4.1" src="https://code.angularjs.org/1.4.1/angular-animate.js"></script>
+    <script src="http://pc035860.github.io/angular-highlightjs/angular-highlightjs.min.js"></script>
+
+    <link href="http://fonts.googleapis.com/css?family=Lato|Oswald" rel="stylesheet" type="text/css" />
+    <!-- <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.3/styles/github.min.css"> -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.6/styles/monokai_sublime.min.css" rel="stylesheet" type="text/css" />
+    <link rel="stylesheet" href="css/main.css" />
+
+    <script src="js/processors-data.js"></script>
+    <script src="js/packages-data.js"></script>
+    <script src="js/main.js"></script>
+  </head>
+
+  <body ng-controller="Main as vm">
+    <div class="container">
+      <div class="head">
+        <div class="text">
+          <span class="title">Dgeni Pipeline</span>
+          <br />
+          <span class="snippet">What each processor does and when</span>
+        </div>
+        <div class="pattern"></div>
+      </div>
+      <div class="contents">
+        <div class="key">
+          <!-- Base packages -->
+          <div class="key-type">
+            <div
+              class="key-item base filterable-package"
+              ng-click="vm.setPackageFilter('base')"
+              ng-class="{ 'active': vm.filterForPackage == 'base' }">
+
+              <div class="key-circle base">
+                <div class="key-circle-inner">
+                  <span class="text">BA</span>
+                </div>
+              </div>
+              <div class="key-text">Base Package</div>
+            </div>
+            <div class="key-item base placeholder">
+              <div class="key-circle base placeholder">
+                <div class="key-circle-inner"></div>
+              </div>
+              <div class="key-text">
+                Psuedo marker <small>(placeholder)</small>
+              </div>
+            </div>
+          </div>
+          <!-- Other packages -->
+          <div class="key-type">
+            <div
+              class="key-item package filterable-package"
+              ng-repeat="p in vm.packages | filter:{ name: '!base' } | filter:vm.hasProcessors | orderBy:'name'"
+              ng-click="vm.setPackageFilter(p.name)"
+              ng-class="{ 'active': p.name == vm.filterForPackage }">
+
+              <div class="key-circle package">
+                <div class="key-circle-inner">
+                  <span class="text" ng-bind="p.abbr"></span>
+                </div>
+              </div>
+              <div class="key-text">{{ p.name }}</div>
+            </div>
+          </div>
+        </div>
+        <div class="panels">
+          <div class="processors">
+            <div class="processor"
+                 ng-repeat="p in vm.processors | filter:{ $package: vm.filterForPackage } | orderBy:'index'"
+                 ng-class="vm.processorClass(p)"
+                 ng-click="vm.selectProcessor(p)">
+
+              {{ p.readableName }}
+            </div>
+          </div>
+          <div class="explanation">
+            <div ng-show="vm.selectedProcessor && vm.selectedProcessor.description"
+                class="explain"
+                ng-class="vm.processorClass(vm.selectedProcessor)"
+                set-class-when-at-top="fixed-top"
+                set-class-watch="vm.selectedProcessor">
+
+              <div class="key-item" ng-class="vm.processorClass(vm.selectedProcessor)">
+                <div class="key-circle" ng-class="vm.processorClass(vm.selectedProcessor)">
+                  <div class="key-circle-inner">
+                    <span class="text" ng-bind="vm.findPackage(vm.selectedProcessor.dgPackage).abbr"></span>
+                  </div>
+                </div>
+                <div class="key-text" ng-bind="vm.selectedProcessor.readableName"></div>
+              </div>
+              <div ng-bind-html="vm.selectedProcessor.description | format"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.6/highlight.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.6/languages/javascript.min.js"></script>
+  </body>
+
+</html>

--- a/docs/config/testPackage.js
+++ b/docs/config/testPackage.js
@@ -1,0 +1,15 @@
+
+var path = require('canonical-path');
+var Package = require('dgeni').Package;
+
+var projectPath = path.resolve(__dirname, '../..');
+
+module.exports = new Package('testPackage', [
+  require(path.resolve(projectPath, 'base')),
+  require(path.resolve(projectPath, 'nunjucks')),
+  require(path.resolve(projectPath, 'jsdoc')),
+  require(path.resolve(projectPath, 'ngdoc')),
+  require(path.resolve(projectPath, 'examples'))
+])
+
+;

--- a/docs/gulpfile.js
+++ b/docs/gulpfile.js
@@ -1,0 +1,95 @@
+var argv = require('yargs')
+  .default('port', 4000)
+  .argv;
+var del = require('del');
+var Dgeni = require('dgeni');
+
+// Gulp dependencies
+var gulp = require('gulp');
+var $g = require('gulp-load-plugins')();
+
+////////////
+
+var config = {
+  paths: {
+    clean: '../.tmp',
+    dist: {
+      docs: '../.tmp/docs',
+      css: '../.tmp/docs/css',
+      js: '../.tmp/docs/js'
+    },
+    js: ['src/js/**/*.js'],
+    less: {
+      src: 'src/less/main.less',
+      watch: ['src/less/**/*.less']
+    },
+    docs: {
+      config: './config',
+      watch: '**',
+      assets: 'assets/**'
+    }
+  }
+};
+
+gulp.task('clean', function (cb) {
+  del(config.paths.clean, cb);
+});
+
+gulp.task('js',  function () {
+  var js = gulp.src(config.paths.js)
+    .pipe($g.plumber())
+    .pipe($g.cached('js'))
+    .pipe($g.jshint())
+    .pipe($g.jscs())
+    .on('error', function () {})
+    .pipe($g.jscsStylish.combineWithHintResults())
+    .pipe($g.jshint.reporter('jshint-stylish'))
+    .pipe($g.ngAnnotate())
+    .pipe(gulp.dest(config.paths.dist.js))
+    .pipe($g.connect.reload());
+});
+
+gulp.task('less', function () {
+  // Process the less files
+  return gulp.src(config.paths.less.src)
+    .pipe($g.cached('less'))
+    .pipe($g.progeny())
+    .pipe($g.less())
+    .pipe(
+      gulp.dest(config.paths.dist.css)
+    )
+    .pipe($g.minifyCss())
+    .pipe($g.rename('main.min.css'))
+    .pipe(
+      gulp.dest(config.paths.dist.css)
+    )
+    .pipe($g.connect.reload());
+});
+
+gulp.task('dgeni', function () {
+  // Copy asset files straight over
+  gulp.src(config.paths.docs.assets, { base: 'docs/assets' })
+    .pipe(gulp.dest(config.paths.dist.docs))
+    .pipe($g.connect.reload());
+
+  var dgeni = new Dgeni([require(config.paths.docs.config)]);
+  dgeni.generate()
+    .then(
+      $g.connect.reload,
+      function (err) {
+        return console.log('error', err);
+      });
+});
+
+gulp.task('watch', ['dgeni', 'less', 'js'], function (done) {
+  gulp.watch(config.paths.js, ['js', 'dgeni']);
+  gulp.watch(config.paths.docs.watch, ['dgeni']);
+  gulp.watch(config.paths.less.watch, ['less']);
+
+  // Fire up connect server
+  return $g.connect.server({
+    root: [config.paths.dist.docs, '..'],
+    port: argv.port,
+    livereload: true
+  });
+});

--- a/docs/src/js/main.js
+++ b/docs/src/js/main.js
@@ -1,0 +1,144 @@
+'use strict';
+
+angular.module('dgeniPipeline', ['ngSanitize', 'ngAnimate', 'hljs', 'constants'])
+
+.controller('Main', function (PACKAGES, PROCESSORS) {
+  var vm = this;
+
+  vm.processorClass = processorClass;
+  vm.selectProcessor = selectProcessor;
+  vm.findPackage = findPackage;
+  vm.setPackageFilter = setPackageFilter;
+  vm.hasProcessors = hasProcessors;
+
+  vm.packages = PACKAGES;
+  vm.processors = PROCESSORS;
+
+  ////////////
+
+  function processorClass (p) {
+    if (!p) return;
+
+    var css = p.dgPackage;
+
+    if (p.placeholder) {
+      css += ' placeholder';
+    }
+
+    if (p.dgPackage !== 'base') {
+      css += ' package';
+    }
+
+    return css;
+  }
+
+  function selectProcessor(p) {
+    if (p.placeholder) {
+      return;
+    }
+
+    vm.selectedProcessor = p;
+  }
+
+  function findPackage(pkgName) {
+    var found = vm.packages.filter(function (p) {
+      return p.name.toLowerCase() === pkgName;
+    });
+
+    return found[0];
+  }
+
+  function setPackageFilter(pkgName) {
+    if (vm.filterForPackage && vm.filterForPackage === pkgName) {
+      vm.filterForPackage = '';
+    }
+    else {
+      vm.filterForPackage = pkgName;
+    }
+
+    vm.selectedProcessor = null;
+  }
+
+  function hasProcessors(pkg) {
+    return vm.processors.some(function (p) {
+      return p.dgPackage === pkg.name;
+    });
+  }
+})
+
+.filter('format', function ($timeout, $compile, $rootScope) {
+  return function (text) {
+    if (!text) return;
+    // return text.replace(/\n/g, '<br>');
+
+    var contents = marked(text);
+    $compile(contents)($rootScope);
+
+    return contents;
+  };
+})
+
+.directive('code', function () {
+  return function ($scope, $elm, $attr) {
+    hljs.highlightBlock($elm[0]);
+  }
+})
+
+.directive('setClassWhenAtTop', function ($window, $timeout) {
+  var $win = angular.element($window); // wrap window object as jQuery object
+
+  return {
+    restrict: 'A',
+    link: function ($scope, $element, $attrs) {
+      var topClass = $attrs.setClassWhenAtTop, // get CSS class from directive's attribute value
+          offsetTop = $element.offset().top; // get element's offset top relative to document
+
+      $win.on('scroll', fixScrollPos);
+      $scope.$watch($attrs.setClassWatch, classWatcherChanged);
+
+      // Update offset-top when packages change, as that will affect this element's positioning
+      $scope.$watch('vm.packages', function () {
+        offsetTop = $element.offset().top - 40;
+      });
+
+      ////////////
+
+      function fixScrollPos(e) {
+        if ($win.scrollTop() >= offsetTop) {
+          var width = $element.width();
+
+          if (width.toString().charAt(0) === '0') {
+            $timeout(function () {
+              width = $element.width();
+
+              if (width.toString().charAt(0) === '0') return;
+
+              $element.css('width', width + 'px');
+              $element.addClass(topClass);
+            });
+          }
+          else {
+            $element.css('width', width + 'px');
+            $element.addClass(topClass);
+          }
+        }
+        else {
+          $element.css('width', '');
+          $element.removeClass(topClass);
+        }
+      }
+
+      function classWatcherChanged(n, o) {
+        if (n !== o) {
+          fixScrollPos();
+        }
+      }
+    }
+  };
+});
+
+////////////
+
+$(document).ready(function () {
+  hljs.initHighlightingOnLoad();
+});

--- a/docs/src/less/main.less
+++ b/docs/src/less/main.less
@@ -1,0 +1,247 @@
+/* Styles go here */
+
+html, body {
+  font-family: 'Lato', sans-serif;
+  font-size: 16px;
+  line-height: 26px;
+}
+
+.fixed-top {
+  position: fixed;
+  top: 0;
+  margin-top: 40px;
+}
+
+.container {
+  background-color: #d6dad6; /* rgba(151, 161, 150, 0.38); */
+  padding: 0;
+  max-width: 1024px;
+  margin: 0 auto;
+}
+
+.head {
+  width: 100%;
+  background-color: #b3a486;
+  color: #552500;
+  text-align: center;
+  position: relative;
+  margin-bottom: 23px;
+}
+
+.head > .text {
+  padding: 50px;
+}
+
+.head .title {
+  font-family: 'Oswald', sans-serif;
+  text-transform: uppercase;
+  font-size: 28.6pt;
+  line-height: 46.3pt;
+  letter-spacing: 10px;
+}
+
+.head .snippet {
+  font-family: 'Lato', sans-serif;
+  opacity: 0.5;
+  font-weight: bold;
+  font-size: 14pt;
+  margin-top: 10px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+}
+
+.pattern {
+  background-image: linear-gradient(320deg, #b3a486 10px, transparent 11px), linear-gradient(40deg, #b3a486 10px, transparent 11px);
+  background-size: 15px 23px;
+  background-repeat: repeat-x;
+  height: 26px;
+  width: 100%;
+  /* transform:rotateZ(90deg) translate(200px,250px); */
+  transform: rotateZ(180deg);
+  bottom: -23px;
+  position: absolute;
+}
+
+.contents {
+  min-height: 800px;
+  padding: 20px 40px 40px 40px;
+  margin-bottom: 20px;
+}
+
+.panels {
+  display: -webkit-flex;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: space-around;
+}
+
+/* Colors */
+
+.base {
+  color: #002f56;
+}
+
+.placeholder {
+  color: #002f56;
+  opacity: 0.5;
+}
+
+.package {
+  color: #b23916;
+}
+
+.package-bg {
+  background-color: #b23916;
+  opacity: 0.5;
+}
+
+/* Legend / Key */
+
+.key {
+  display: -webkit-flex;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: space-around;
+  margin-bottom: 80px;
+}
+
+.key-type {
+  display: -webkit-flex;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  justify-content: flex-start;
+}
+
+.key-item {
+  display: flex;
+  display: -webkit-flex;
+  font-weight: bold;
+  // padding: 4px 8px 4px 0;
+  padding: 8px;
+  line-height: 20px;
+  flex-direction: row;
+}
+
+.key-circle {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  position: relative;
+  color: #ededed;
+  background-color: transparent;
+  border: 3px solid white;
+}
+
+.key-circle-inner {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  text-align: center;
+  border: 3px solid transparent;
+}
+
+.key-circle-inner > .text {
+  /* padding-left: 8px; */
+  line-height: 28px;
+  font-size: 14px;
+}
+
+.key-text {
+  font-size: 20px;
+  padding: 8px;
+}
+
+.key-circle.base {
+  border-color: #002f56;
+}
+.key-circle.base > .key-circle-inner {
+  background-color: #002f56;
+}
+
+.key-circle.package {
+  border-color: #b23916;
+}
+.key-circle.package > .key-circle-inner {
+  background-color: #b23916;
+}
+
+// A package that can be clicked and filtered
+.key .key-item.filterable-package {
+  cursor: pointer;
+
+  &.active {
+    border-radius: 4px;
+    background-color: darken(#d6dad6, 20%);
+  }
+}
+
+/* Explanation */
+
+.explanation {
+  flex: 2 0 0;
+  /* border: 1px solid black; */
+}
+
+.explain {
+  border-radius: 8px;
+  font-weight: normal;
+  color: #ececec;
+  padding: 20px;
+
+  &.base {
+    background-color: rgba(0, 47, 86, 0.5);
+  }
+
+  &.package {
+    background-color: rgba(178, 57, 22, 0.5);
+  }
+}
+
+
+/* Processors */
+
+.processors {
+  display: -webkit-flex;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  justify-content: flex-start;
+  align-content: flex-start;
+  flex: 1 1 0;
+  /* border: 1px solid black; */
+}
+
+.processor {
+  font-weight: bold;
+  color: #b23916;
+  padding: 4px 8px;
+  cursor: pointer;
+
+  &.placeholder {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  &.active {
+    background-color: rgba(178, 57, 22, 0.5);
+    border-radius: 4px;
+  }
+
+  &.base {
+    color: #002f56;
+
+    &.active {
+      background-color: rgba(0, 47, 86, 0.5);
+    }
+  }
+}
+
+pre code {
+  border-radius: 4px;
+}

--- a/examples/index.js
+++ b/examples/index.js
@@ -2,6 +2,10 @@ var path = require('canonical-path');
 var packagePath = __dirname;
 var Package = require('dgeni').Package;
 
+/**
+ * @dgPackage examples
+ * @description Processors to support the runnable examples feature in the AngularJS docs site.
+ */
 module.exports = new Package('examples', ['jsdoc'])
 
 .processor(require('./processors/examples-parse'))

--- a/examples/processors/examples-generate.js
+++ b/examples/processors/examples-generate.js
@@ -4,7 +4,7 @@ var path = require('canonical-path');
 /**
  * @dgProcessor generateExamplesProcessor
  * @description
- * Create doc objects of the various things that need to be rendered for an example
+ * Create doc objects of the various things that need to be rendered for an example.
  * This includes the files that will be run in an iframe, the code that will be injected
  * into the HTML pages and the protractor test files.
  */

--- a/examples/processors/protractor-generate.js
+++ b/examples/processors/protractor-generate.js
@@ -3,7 +3,7 @@
 var _ = require('lodash');
 
 /**
- * dgProcessor generateProtractorTestsProcessor
+ * @dgProcessor generateProtractorTestsProcessor
  * @description
  * Generate a protractor test files from the e2e tests in the examples
  */

--- a/jsdoc/index.js
+++ b/jsdoc/index.js
@@ -1,6 +1,10 @@
 var path = require('canonical-path');
 var Package = require('dgeni').Package;
 
+/**
+ * @dgPackage jsdoc
+ * @description Tag parsing and extracting for JSDoc-based documentation
+ */
 module.exports = new Package('jsdoc', [require('../base')])
 
 // Add in extra pseudo marker processors

--- a/jsdoc/processors/extract-tags.js
+++ b/jsdoc/processors/extract-tags.js
@@ -1,7 +1,7 @@
 var _ = require('lodash');
 
 /**
- * dgProcessor extract-tags
+ * @dgProcessor extract-tags
  * @description
  * Extract the information from the tags that were parsed
  */

--- a/ngdoc/index.js
+++ b/ngdoc/index.js
@@ -1,6 +1,10 @@
 var path = require('canonical-path');
 var Package = require('dgeni').Package;
 
+/**
+ * @dgPackage ngdoc
+ * @description AngularJS specific tag-defs, processors and templates. This loads the jsdoc and nunjucks packages for you.
+ */
 module.exports = new Package('ngdoc', [require('../jsdoc'), require('../nunjucks')])
 
 .factory(require('./file-readers/ngdoc'))

--- a/ngdoc/processors/filterNgdocs.js
+++ b/ngdoc/processors/filterNgdocs.js
@@ -1,7 +1,7 @@
 var _ = require('lodash');
 
 /**
- * dgProcessor filterNgDocsProcessor
+ * @dgProcessor filterNgDocsProcessor
  * @description
  * Remove docs that do not contain the ngdoc tag
  */

--- a/package.json
+++ b/package.json
@@ -56,7 +56,26 @@
   "devDependencies": {
     "istanbul": "^0.2.7",
     "jasmine-node": "^2.0.0",
-    "rewire": "~2.0.0"
+    "rewire": "~2.0.0",
+    "del": "^1.2.0",
+    "gulp": "^3.9.0",
+    "gulp-cached": "^1.1.0",
+    "gulp-progeny": "0.0.7",
+    "gulp-size": "^1.2.2",
+    "gulp-less": "^3.0.3",
+    "gulp-connect": "^2.2.0",
+    "yargs": "^3.13.0",
+    "gulp-jscs-stylish": "^1.1.0",
+    "gulp-ng-annotate": "^1.0.0",
+    "gulp-jshint": "^1.11.0",
+    "gulp-jscs": "^1.6.0",
+    "gulp-load-plugins": "^1.0.0-rc.1",
+    "gulp-minify-css": "^1.2.0",
+    "gulp-rename": "^1.2.2",
+    "gulp-plumber": "^1.0.1",
+    "jshint-stylish": "^2.0.1",
+    "jscs-stylish": "^0.3.1",
+    "lodash": "~2.4.2"
   },
   "contributors": [
     "Peter Bacon Darwin <pete@bacondarwin.com>",


### PR DESCRIPTION
I was having a lot of trouble understanding the order that Dgeni's processors run in, and what they do, so I wrote a Dgeni package that takes all of the Dgeni packages and processors, and generates a single-page Angular app where you can:
* View the processors in order that they run
* Filter the processors by their parent package
* Read the description docs from the processors 

You can see a live example on this fork's github branch: http://c0bra.github.io/dgeni-packages/

This may or may not be helpful to this project, and it could use some design TLC, but it **really** helped me get a picture of what exactly is happening and when in Dgeni's guts.

I thought I would submit a PR in case this is beneficial. If not, feel free to close it or cannibalize the changes however you want.