### PR TITLE
Update the estraverse library to the latest to enable support for more ES6 functionality

### DIFF
--- a/jsdoc/file-readers/jsdoc.js
+++ b/jsdoc/file-readers/jsdoc.js
@@ -1,5 +1,4 @@
 var _ = require('lodash');
-var esprima = require('esprima');
 
 /**
  * @dgService jsdocFileReader
@@ -7,17 +6,14 @@ var esprima = require('esprima');
  * This file reader will create a simple doc for each js
  * file including a code AST of the JavaScript in the file.
  */
-module.exports = function jsdocFileReader(log) {
+module.exports = function jsdocFileReader(log, jsParser) {
   return {
     name: 'jsdocFileReader',
     defaultPattern: /\.js$/,
     getDocs: function(fileInfo) {
 
       try {
-        fileInfo.ast = esprima.parse(fileInfo.content, {
-          loc: true,
-          attachComment: true
-        });
+        fileInfo.ast = jsParser(fileInfo.content);
       } catch(ex) {
        ex.file = fileInfo.filePath;
         throw new Error(

--- a/jsdoc/index.js
+++ b/jsdoc/index.js
@@ -23,6 +23,7 @@ module.exports = new Package('jsdoc', [require('../base')])
 .factory(require('./services/transforms/whole-tag'))
 .factory(require('./services/transforms/trim-whitespace'))
 
+.factory(require('./services/jsParser'))
 .factory(require('./file-readers/jsdoc'))
 
 // Configure the processors

--- a/jsdoc/processors/code-name.js
+++ b/jsdoc/processors/code-name.js
@@ -55,6 +55,8 @@ module.exports = function codeNameProcessor(log) {
         return findCodeName(node.declarations[0]);
       case 'VariableDeclarator':
         return node.id && node.id.name;
+      case 'ExportDefaultDeclaration':
+        return null;
       default:
         log.warn('HELP! Unrecognised node type: ' + node.type);
         log.warn(node);

--- a/jsdoc/processors/code-name.js
+++ b/jsdoc/processors/code-name.js
@@ -19,7 +19,7 @@ module.exports = function codeNameProcessor(log) {
 
   /**
    * Recurse down the code AST node that is associated with this doc for a name
-   * @param  {Object} node The esprima node information for the code to find the name of
+   * @param  {Object} node The JS AST node information for the code to find the name of
    * @return {String}      The name of the code or null if none found.
    */
   function findCodeName(node) {

--- a/jsdoc/processors/code-name.spec.js
+++ b/jsdoc/processors/code-name.spec.js
@@ -1,20 +1,28 @@
-var codeNameProcessorFactory = require('./code-name');
-var jsParser = require('esprima');
+var Dgeni = require('dgeni');
+var mockPackage = require('../mocks/mockPackage');
 
 var mockLog = jasmine.createSpyObj('log', ['error', 'warn', 'info', 'debug', 'silly']);
 
 describe('code-name doc processor', function() {
+  
+  var jsParser, processor;
+  
+  beforeEach(function() {
+    var dgeni = new Dgeni([mockPackage()]);
+    var injector = dgeni.configureInjector();
+    jsParser = injector.get('jsParser');  
+    processor = injector.get('codeNameProcessor');
+  });
+  
   it("should understand CallExpressions", function() {
-    var processor = codeNameProcessorFactory(mockLog);
-    var ast = jsParser.parse('(function foo() { })()');
+    var ast = jsParser('(function foo() { })()');
     var doc = { codeNode: ast };
     processor.$process([doc]);
     expect(doc.codeName).toEqual('foo');
   });
 
   it("should understand ArrayExpressions", function() {
-    var processor = codeNameProcessorFactory(mockLog);
-    var ast = jsParser.parse("$CompileProvider.$inject = ['$provide', '$$sanitizeUriProvider'];");
+    var ast = jsParser("$CompileProvider.$inject = ['$provide', '$$sanitizeUriProvider'];");
     var doc = { codeNode: ast };
     processor.$process([doc]);
     expect(doc.codeName).toEqual('$inject');

--- a/jsdoc/processors/extractJSDocComments.spec.js
+++ b/jsdoc/processors/extractJSDocComments.spec.js
@@ -1,5 +1,4 @@
 var path = require('canonical-path');
-var esprima = require('esprima');
 var Dgeni = require('dgeni');
 var mockPackage = require('../mocks/mockPackage');
 
@@ -9,7 +8,7 @@ var docsFromJsContent = require('../mocks/_test-data/docsFromJsFile');
 
 describe("extractJSDocCommentsProcessor", function() {
 
-  var processor;
+  var processor, jsParser;
 
   var createFileInfo = function(file, content, basePath) {
     return {
@@ -19,10 +18,7 @@ describe("extractJSDocCommentsProcessor", function() {
       basePath: basePath,
       relativePath: path.relative(basePath, file),
       content: content,
-      ast: esprima.parse(content, {
-        loc: true,
-        attachComment: true
-      }),
+      ast: jsParser(content),
     };
   };
 
@@ -36,7 +32,7 @@ describe("extractJSDocCommentsProcessor", function() {
   beforeEach(function() {
     dgeni = new Dgeni([mockPackage()]);
     var injector = dgeni.configureInjector();
-
+    jsParser = injector.get('jsParser');
     processor = injector.get('extractJSDocCommentsProcessor');
   });
 

--- a/jsdoc/services/jsParser.js
+++ b/jsdoc/services/jsParser.js
@@ -1,0 +1,102 @@
+var jsParserImpl = require('espree');
+
+module.exports = function jsParser() {
+  return function(code) {
+    return jsParserImpl.parse(code, {
+    
+        // attach range information to each node
+        range: true,
+    
+        // attach line/column location information to each node
+        loc: true,
+    
+        // create a top-level comments array containing all comments
+        comments: true,
+    
+        // attach comments to the closest relevant node as leadingComments and
+        // trailingComments
+        attachComment: true,
+    
+        // create a top-level tokens array containing all tokens
+        tokens: true,
+    
+        // try to continue parsing if an error is encountered, store errors in a
+        // top-level errors array
+        tolerant: true,
+    
+        // specify parsing features (default only has blockBindings: true)
+        // setting this option replaces the default values
+        ecmaFeatures: {
+    
+            // enable parsing of arrow functions
+            arrowFunctions: true,
+    
+            // enable parsing of let/const
+            blockBindings: true,
+    
+            // enable parsing of destructured arrays and objects
+            destructuring: true,
+    
+            // enable parsing of regular expression y flag
+            regexYFlag: true,
+    
+            // enable parsing of regular expression u flag
+            regexUFlag: true,
+    
+            // enable parsing of template strings
+            templateStrings: true,
+    
+            // enable parsing of binary literals
+            binaryLiterals: true,
+    
+            // enable parsing of ES6 octal literals
+            octalLiterals: true,
+    
+            // enable parsing unicode code point escape sequences
+            unicodeCodePointEscapes: true,
+    
+            // enable parsing of default parameters
+            defaultParams: true,
+    
+            // enable parsing of rest parameters
+            restParams: true,
+    
+            // enable parsing of for-of statement
+            forOf: true,
+    
+            // enable parsing computed object literal properties
+            objectLiteralComputedProperties: true,
+    
+            // enable parsing of shorthand object literal methods
+            objectLiteralShorthandMethods: true,
+    
+            // enable parsing of shorthand object literal properties
+            objectLiteralShorthandProperties: true,
+    
+            // Allow duplicate object literal properties (except '__proto__')
+            objectLiteralDuplicateProperties: true,
+    
+            // enable parsing of generators/yield
+            generators: true,
+    
+            // enable parsing spread operator
+            spread: true,
+    
+            // enable super in functions
+            superInFunctions: true,
+    
+            // enable parsing classes
+            classes: true,
+    
+            // enable parsing of modules
+            modules: true,
+    
+            // enable React JSX parsing
+            jsx: true,
+    
+            // enable return in global scope
+            globalReturn: true
+        }
+    });
+  };
+};

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "catharsis": "^0.8.1",
     "change-case": "^2.1.0",
     "dgeni": "^0.4.0",
-    "esprima": "^1.0.4",
+    "espree": "^2.1.0",
     "estraverse": "^1.5.1",
     "glob": "~3.2.8",
     "htmlparser2": "^3.7.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "change-case": "^2.1.0",
     "dgeni": "^0.4.0",
     "espree": "^2.1.0",
-    "estraverse": "^1.5.1",
+    "estraverse": "^4.1.0",
     "glob": "~3.2.8",
     "htmlparser2": "^3.7.3",
     "lodash": "~2.4.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "catharsis": "^0.8.1",
     "change-case": "^2.1.0",
     "dgeni": "^0.4.0",
-    "espree": "^2.1.0",
+    "espree": "^2.2.3",
     "estraverse": "^4.1.0",
     "glob": "~3.2.8",
     "htmlparser2": "^3.7.3",


### PR DESCRIPTION
Update the estraverse library to the latest to enable support for ExportDefaultDeclaration and a number of other ES6 conventions.

Fixes issue:

File Reader: jsdocFileReader
info:    running processor: extractJSDocCommentsProcessor
error:   Error: Unknown node type ExportDefaultDeclaration.
    at Controller.traverse (.../packages/node_modules/estraverse/estraverse.js:517:31)
