### PR TITLE
fix(jsdoc) file-readers assignment via concat

### DIFF
--- a/jsdoc/index.js
+++ b/jsdoc/index.js
@@ -28,7 +28,7 @@ module.exports = new Package('jsdoc', [require('../base')])
 // Configure the processors
 
 .config(function(readFilesProcessor, jsdocFileReader) {
-  readFilesProcessor.fileReaders = [jsdocFileReader];
+  readFilesProcessor.fileReaders = [jsdocFileReader].concat(readFilesProcessor.fileReaders || []);
 })
 
 .config(function(parseTagsProcessor, getInjectables) {


### PR DESCRIPTION
Updated the readfilesProcess.fileReaders assignment to concat the array with the original value. Prevents dgeni-packages/jsdoc from overwriting the assignment if it is declared as a later dependency.