### PR TITLE
Move installation documentation to the top

### DIFF
--- a/ngdoc/templates/api/module.template.html
+++ b/ngdoc/templates/api/module.template.html
@@ -5,8 +5,6 @@
   {% if doc.title %}{$ doc.title | marked $}{% else %}{$ doc.name | code $}{% endif %}
 </h1>
 
-{$ doc.description | marked $}
-
 {% if doc.name != 'ng' and doc.name != 'auto' %}
   <h2>Installation</h2>
 
@@ -40,6 +38,8 @@
 
   <p>With that you&apos;re ready to get started!</p>
 {% endif %}
+
+{$ doc.description | marked $}
 
 <div class="component-breakdown">
   <h2>Module Components</h2>


### PR DESCRIPTION
When learning about an Angular module, it is not obvious sometimes that a module is external from looking at the docs and trying to learn about it. 

Example: ngMessages.

If you never used it before, you might think it comes with Angular and waste time on debugging why it is not working.

Like on any github readme.md file, I think it might be better to start the doc with the installation requirements to indicate this is an external module you need to bower/npm install