### PR TITLE
Changed the INLINE_TAG regex to allow curly brackets

### DIFF
--- a/jsdoc/processors/inline-tags.js
+++ b/jsdoc/processors/inline-tags.js
@@ -1,5 +1,5 @@
 var _ = require('lodash');
-var INLINE_TAG = /\{@([^\s]+)\s+([^\}]*)\}/g;
+var INLINE_TAG = /(?:^|)\{@([^\s]+)\s+(.*)\}(?:$|)/g;
 var StringMap = require('stringmap');
 
 /**


### PR DESCRIPTION
At the moment it is not possible to use curly brackets in an inline-tag defenition because the first closing one will close the inline tag:

{@formatObject {image: {picture: 'personPicId'}, details: {name: 'personName'}}}

I just changed the regex INLINE_TAG to:

`/(?:^|)\{@([^\s]+)\s+(.*)\}(?:$|)/g;`