### PR TITLE
fix(code-name): add support for MethodDefinition, ArrowFunctionExpression nodes

### DIFF
--- a/jsdoc/processors/code-name.js
+++ b/jsdoc/processors/code-name.js
@@ -57,6 +57,10 @@ module.exports = function codeNameProcessor(log) {
         return node.id && node.id.name;
       case 'ExportDefaultDeclaration':
         return null;
+      case 'MethodDefinition':
+        return findCodeName(node.key);
+      case 'ArrowFunctionExpression':
+        return null;
       default:
         log.warn('HELP! Unrecognised node type: ' + node.type);
         log.warn(node);


### PR DESCRIPTION
Some of the ES6 features used in a project I'm working on throw `Unrecognised node type` warnings from this processor, so I've added the missing nodes. Let me know if there are better values to return - these seemed to make sense based on the codebase I'm working in and the ESTree [docs](https://github.com/estree/estree/blob/master/es6.md).