### PR TITLE
Use link filter for module link in ngdoc api template

### DIFF
--- a/ngdoc/templates/api/api.template.html
+++ b/ngdoc/templates/api/api.template.html
@@ -8,7 +8,7 @@
   <ol class="api-profile-header-structure naked-list step-list">
     {% block related_components %}{% endblock %}
     <li>
-      - {$ doc.docType $} in module <a href="{$ doc.moduleDoc.path $}">{$ doc.moduleDoc.name $}</a>
+      - {$ doc.docType $} in module {$ doc.moduleDoc.id | link(doc.moduleDoc.name, doc.moduleDoc) $}
     </li>
   </ol>
 </header>


### PR DESCRIPTION
This allows the module link to work when relative links are enabled