### PR TITLE
git: make package url more flexible

### DIFF
--- a/git/services/gitRepoInfo.js
+++ b/git/services/gitRepoInfo.js
@@ -5,7 +5,7 @@
  * @return {Object} An object containing the github owner and repository name
  */
 module.exports = function gitRepoInfo(packageInfo) {
-  var GITURL_REGEX = /^https:\/\/github.com\/([^\/]+)\/(.+).git$/;
+  var GITURL_REGEX = /^https?:\/\/[^\/]+\/([^\/]+)\/(.+).git$/;
   var match = GITURL_REGEX.exec(packageInfo.repository.url);
   return {
     owner: match[1],

--- a/git/services/gitRepoInfo.spec.js
+++ b/git/services/gitRepoInfo.spec.js
@@ -19,7 +19,6 @@ describe("gitRepoInfo", function() {
     expect(gitRepoInfo).not.toBe(null);
   });
 
-
   it("should have owner set from package repository url", function() {
     expect(gitRepoInfo.owner).toBe('owner');
   });
@@ -37,25 +36,4 @@ describe("gitRepoInfo", function() {
 
     expect(function(){injector.get('gitRepoInfo')}).toThrow();
   });
-
-  it("should throw an error if not a github repo url", function() {
-    var badPackage = {
-      repository: {
-        url: 'https://abc.com/foo/bar.git'
-      }
-    };
-
-    mockPackage.factory(function packageInfo() {
-      return badPackage;
-    });
-    var dgeni = new Dgeni([mockPackage]);
-    var injector = dgeni.configureInjector();
-
-    expect(function(){injector.get('gitRepoInfo')}).toThrow();
-
-    expect(gitRepoInfoFactory).toThrow();
-  });
-
-
 });
-


### PR DESCRIPTION
We are using a private git repository (on premise) which also uses the same url syntax (username/package-name) as github. Is there any reason to be github specific?

fixes #151