### PR TITLE
Add support for extracting ngdocs from AngularJS AST

### DIFF
--- a/angular/index.js
+++ b/angular/index.js
@@ -1,0 +1,63 @@
+'use strict';
+
+var dgeni = require('dgeni');
+
+
+module.exports = new dgeni.Package('angular', [
+  require('dgeni-packages/ngdoc')
+])
+
+.processor(require('./processors/extract-angular-ast'))
+.processor(require('./processors/generate-angular-tags'))
+.processor(require('./processors/resolve-angular-components'))
+
+.factory(require('./services/angular-components'))
+.factory(require('./services/escope-map'))
+.factory(require('./services/resolve-class-like'))
+.factory(require('./services/resolve-di'))
+.factory(require('./services/resolve-identifier-node'))
+.factory(require('./services/resolve-object'))
+.factory(require('./services/resolve-return-object'))
+
+.config(function(angularComponents, resolveClassLike, resolveObject, resolveReturnObject) {
+  angularComponents.add('animation', {
+    resolveValue: resolveObject
+  });
+  angularComponents.add('component', {
+    ngdoc: 'directive',
+    resolveValue: resolveObject
+  });
+  angularComponents.add('config', {
+    skip: true
+  });
+  angularComponents.add('constant', {
+    resolveValue: resolveObject
+  });
+  angularComponents.add('controller', {
+    resolveValue: resolveClassLike
+  });
+  angularComponents.add('decorator', {});
+  angularComponents.add('directive', {
+    resolveValue: resolveReturnObject
+  });
+  angularComponents.add('factory', {
+    ngdoc: 'service',
+    resolveValue: resolveReturnObject
+  });
+  angularComponents.add('filter', {
+    resolveValue: resolveReturnObject
+  });
+  angularComponents.add('provider', {
+    resolveValue: resolveClassLike
+  });
+  angularComponents.add('run', {
+    skip: true
+  });
+  angularComponents.add('service', {
+    resolveValue: resolveClassLike
+  });
+  angularComponents.add('value', {
+    ngdoc: 'service',
+    resolveValue: resolveObject
+  });
+});

--- a/angular/index.js
+++ b/angular/index.js
@@ -4,7 +4,7 @@ var dgeni = require('dgeni');
 
 
 module.exports = new dgeni.Package('angular', [
-  require('dgeni-packages/ngdoc')
+  require('../ngdoc')
 ])
 
 .processor(require('./processors/extract-angular-ast'))

--- a/angular/processors/extract-angular-ast.js
+++ b/angular/processors/extract-angular-ast.js
@@ -1,0 +1,140 @@
+'use strict';
+
+var _ = require('lodash');
+var escope = require('escope');
+var estraverse = require('estraverse');
+
+var util = require('../util');
+
+
+module.exports = function extractAngularAstProcessor(angularComponents, escopeMap, log) {
+  return {
+    $runAfter: ['files-read'],
+    $runBefore: ['extractJSDocCommentsProcessor'],
+    $process: $process
+  };
+
+  function $process(docs) {
+    var autoDocs = _.flatten(
+      docs
+        .filter(doc => doc.docType === 'jsFile')
+        .map(processAst));
+    log.info(`Extracted ${autoDocs.length} AngularJS components`);
+    Array.prototype.push.apply(docs, autoDocs);
+  }
+
+  function processAst(jsFileDoc) {
+    var fileInfo = jsFileDoc.fileInfo;
+    var ast = fileInfo.ast;
+    var result = [];
+    var scopeManager = escope.analyze(ast);
+    var currentScope = scopeManager.acquire(ast);
+    estraverse.traverse(ast, {
+      enter: function(node) {
+        if (/Function/.test(node.type)) {
+          currentScope = scopeManager.acquire(node);
+        }
+
+        escopeMap.set(node, currentScope);
+
+        if (node.type === 'ExpressionStatement') {
+          Array.prototype.push.apply(result, processAngularChain(node));
+        }
+      },
+      leave: function(node) {
+        if (/Function/.test(node.type)) {
+          currentScope = currentScope.upper;
+        }
+      }
+    });
+    // console.dir(result, {depth: 1, colors: true});
+    log.debug(`Extracted ${result.length} AngularJS components from ${fileInfo.relativePath}`);
+    result.forEach(function(doc) {
+      doc.fileInfo = fileInfo;
+    });
+    return result;
+  }
+
+  function isAngularModuleCall(node) {
+    if (node.type !== 'CallExpression') {
+      return false;
+    }
+    if (node.callee.type !== 'MemberExpression') {
+      return false;
+    }
+    if (node.callee.object.type !== 'Identifier') {
+      return false;
+    }
+    if (node.callee.object.name !== 'angular') {
+      return false;
+    }
+    if (node.callee.property.name !== 'module') {
+      return false;
+    }
+    return true;
+  }
+
+  function processAngularChain(node) {
+    var moduleDoc;
+    var result = [];
+    var current = node.expression;
+    while (current.type === 'CallExpression') {
+      if (current.callee.type !== 'MemberExpression') {
+        break;
+      }
+      if (isAngularModuleCall(current)) {
+        moduleDoc = {
+          callExpression: current,
+          docType: 'autoDoc',
+          autoTags: {
+            ngdoc: ['module'],
+            name: [current.arguments[0].value]
+          },
+          content: util.getMatchingJSDoc(node.leadingComments)
+        };
+        break;
+      }
+      var definition = angularComponents.get(current.callee.property.name);
+      if (definition) {
+        if (definition.skip) {
+          current = current.callee.object;
+          continue;
+        }
+        if (current.arguments.length < definition.argumentCount) {
+          log.error(`Invalid AngularJS ${definition.name} definition. Too few arguments.`);
+        }
+        var doc = {
+          callExpression: current,
+          docType: 'autoDoc',
+          autoDocDefinition: definition,
+          autoDocName: current.callee.property.name,
+          autoTags: {
+            ngdoc: [definition.ngdoc],
+            name: [current.arguments[0].value]
+          },
+          content: util.getMatchingJSDoc(current.callee.property.leadingComments)
+        };
+        result.push(doc);
+      } else {
+        result.length = 0;
+      }
+      current = current.callee.object;
+    }
+    if (!moduleDoc) {
+      return [];
+    }
+    result.forEach(function(doc) {
+      doc.autoTags.module = [moduleDoc.autoTags.name[0]];
+    });
+    if (moduleDoc.callExpression.arguments.length > 1) {
+      if (moduleDoc.callExpression.arguments[1].type === 'ArrayExpression') {
+        moduleDoc.autoTags.requires = moduleDoc.callExpression.arguments[1].elements
+          .filter(element => element.type === 'Literal')
+          .map(element => element.value);
+      }
+      result.push(moduleDoc);
+      log.debug('Extracted module ' + moduleDoc.autoTags.name[0]);
+    }
+    return result;
+  }
+};

--- a/angular/processors/generate-angular-tags.js
+++ b/angular/processors/generate-angular-tags.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var _ = require('lodash');
+var Tag = require('dgeni-packages/jsdoc/lib/Tag');
+
+
+module.exports = function generateAngularTagsProcessor(parseTagsProcessor) {
+  return {
+    $runAfter: ['parseTagsProcessor'],
+    $runBefore: ['filterNgDocsProcessor'],
+    $process: $process
+  };
+
+  function $process(docs) {
+    var tagDefMap = {};
+    parseTagsProcessor.tagDefinitions.forEach(function(tagDef) {
+      tagDefMap[tagDef.name] = tagDef;
+    });
+
+    docs
+      .filter(doc => doc.autoTags)
+      .forEach(parseAutoTags);
+
+    function parseAutoTags(doc) {
+      _.forEach(doc.autoTags, function(descriptions, tagName) {
+        descriptions.forEach(function(description) {
+          doc.tags.addTag(new Tag(tagDefMap[tagName], tagName, description));
+        });
+      });
+    }
+  }
+};

--- a/angular/processors/generate-angular-tags.js
+++ b/angular/processors/generate-angular-tags.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var _ = require('lodash');
-var Tag = require('dgeni-packages/jsdoc/lib/Tag');
+var Tag = require('../../jsdoc/lib/Tag');
 
 
 module.exports = function generateAngularTagsProcessor(parseTagsProcessor) {

--- a/angular/processors/resolve-angular-components.js
+++ b/angular/processors/resolve-angular-components.js
@@ -1,0 +1,30 @@
+'use strict';
+
+
+module.exports = function resolveAngularComponentsProcessor(angularComponents, log, resolveDI, resolveIdentifierNode) {
+  return {
+    $runAfter: ['extractAngularAstProcessor'],
+    $runBefore: ['parsing-tags'],
+    $process: $process
+  };
+
+  function $process(docs) {
+    docs
+      .filter(doc => doc.docType === 'autoDoc')
+      .filter(doc => doc.autoTags.ngdoc[0] !== 'module')
+      .forEach(function(doc) {
+        var definition = angularComponents.get(doc.autoDocName);
+        log.debug('Resolving', doc.autoTags.name[0]);
+        var value = resolveIdentifierNode(doc.callExpression.arguments[1]);
+        if (!value) {
+          return;
+        }
+        var members = definition.resolveValue(doc, value);
+        members.forEach(function(member) {
+          log.debug('Extracted member ' + member.autoTags.name[0]);
+        });
+        Array.prototype.push.apply(docs, members);
+        resolveDI(value, doc);
+      });
+  }
+};

--- a/angular/processors/resolve-angular-components.js
+++ b/angular/processors/resolve-angular-components.js
@@ -20,9 +20,11 @@ module.exports = function resolveAngularComponentsProcessor(angularComponents, l
           return;
         }
         var members = definition.resolveValue(doc, value);
-        members.forEach(function(member) {
-          log.debug('Extracted member ' + member.autoTags.name[0]);
-        });
+        if (members) {
+          members.forEach(function(member) {
+            log.debug('Extracted member ' + member.autoTags.name[0]);
+          });
+        }
         Array.prototype.push.apply(docs, members);
         resolveDI(value, doc);
       });

--- a/angular/services/angular-components.js
+++ b/angular/services/angular-components.js
@@ -1,0 +1,25 @@
+'use strict';
+
+
+module.exports = function angularComponents() {
+  var definitions = {};
+
+  return {
+    add: add,
+    get: get
+  };
+
+  function add(name, definition) {
+    if (!definition.ngdoc) {
+      definition.ngdoc = name;
+    }
+    if (isNaN(definition.argumentCount)) {
+      definition.argumentCount = 2;
+    }
+    definitions[name] = definition;
+  }
+
+  function get(name) {
+    return definitions[name];
+  }
+};

--- a/angular/services/escope-map.js
+++ b/angular/services/escope-map.js
@@ -1,0 +1,6 @@
+'use strict';
+
+
+module.exports = function escopeMap() {
+  return new Map();
+};

--- a/angular/services/resolve-class-like.js
+++ b/angular/services/resolve-class-like.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var util = require('../util');
+
+
+module.exports = function resolveClassLike(log, resolveIdentifierNode) {
+  return function(doc, value) {
+    var result = [];
+    value.body.body.some(function(statement) {
+      // No valid members can be declared after a return statement,
+      if (statement.type === 'ReturnStatement') {
+        return true;
+      }
+      // Probably a function declaration, ignoring...
+      if (statement.type !== 'ExpressionStatement') {
+        return;
+      }
+      var expression = statement.expression;
+      // As far as we're concerned, only assignments can define members.
+      if (expression.type !== 'AssignmentExpression') {
+        return;
+      }
+      // Not interested in variable assignments.
+      if (expression.left.type !== 'MemberExpression') {
+        return;
+      }
+      // Not an assignment to `this`.
+      if (expression.left.object.type !== 'ThisExpression') {
+        return;
+      }
+      var resolved = resolveIdentifierNode(expression.right);
+      if (/Function/.test(resolved.type)) {
+        var name = doc.autoTags.name[0] + '#' + expression.left.property.name;
+        result.push({
+          docType: 'autoDoc',
+          fileInfo: doc.fileInfo,
+          autoTags: {
+            ngdoc: ['method'],
+            name: [name]
+          },
+          content: util.getMatchingJSDoc([].concat(statement.leadingComments, resolved.leadingComments))
+        });
+      }
+    });
+    return result;
+  };
+};

--- a/angular/services/resolve-di.js
+++ b/angular/services/resolve-di.js
@@ -1,0 +1,11 @@
+'use strict';
+
+
+module.exports = function resolveDI() {
+  return function(node, doc) {
+    if (!node || !node.params) {
+      return;  // XXX Remove this check.
+    }
+    doc.autoTags.requires = node.params.map(param => param.name);
+  };
+};

--- a/angular/services/resolve-identifier-node.js
+++ b/angular/services/resolve-identifier-node.js
@@ -1,0 +1,24 @@
+'use strict';
+
+
+module.exports = function resolveIdentifierNode(escopeMap) {
+  return function(node) {
+    if (node.type !== 'Identifier') {
+      return node;
+    }
+    var scope = escopeMap.get(node);
+    var result = null;
+    scope.variables.some(function(variable) {
+      if (variable.name !== node.name) {
+        return;
+      }
+      return variable.defs.some(function(def) {
+        if (def.type === 'FunctionName') {
+          result = def.node;
+          return true;
+        }
+      });
+    });
+    return result;
+  };
+};

--- a/angular/services/resolve-object.js
+++ b/angular/services/resolve-object.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var util = require('../util');
+
+
+module.exports = function resolveObject(log, resolveIdentifierNode) {
+  return function(doc, value) {
+    if (value.type === 'FunctionExpression') {
+      // XXX Handle @kind function
+    }
+    if (value.type === 'ObjectExpression') {
+      return value.properties.map(function(property) {
+        var name = doc.autoTags.name[0] + '#' + property.key.name;
+        var propertyValue = resolveIdentifierNode(property);
+        return {
+          docType: 'autoDoc',
+          fileInfo: doc.fileInfo,
+          autoTags: {
+            ngdoc: ['method'],
+            name: [name]
+          },
+          content: util.getMatchingJSDoc([].concat(property.leadingComments, propertyValue.leadingComments))
+        };
+      });
+    }
+  };
+};

--- a/angular/services/resolve-return-object.js
+++ b/angular/services/resolve-return-object.js
@@ -1,0 +1,17 @@
+'use strict';
+
+
+module.exports = function resolveReturnObject(log, resolveIdentifierNode, resolveObject) {
+  return function(doc, value) {
+    var result = [];
+    value.body.body.some(function(statement) {
+      if (statement.type !== 'ReturnStatement') {
+        return;
+      }
+      var returnValue = statement.argument;
+      result = resolveObject(doc, returnValue);
+      return true;
+    });
+    return result;
+  };
+};

--- a/angular/util.js
+++ b/angular/util.js
@@ -1,0 +1,31 @@
+'use strict';
+
+// Nicely stolen from extractJSDocCommentsProcessor
+var LEADING_STAR = /^[^\S\r\n]*\*[^\S\n\r]?/gm;
+
+
+module.exports = {
+  getMatchingJSDoc: getMatchingJSDoc,
+  resolveIdentifier: resolveIdentifier
+};
+
+
+function getMatchingJSDoc(comments) {
+  if (!comments) {
+    return null;
+  }
+  for (var i = comments.length; i > 0; i--) {
+    var comment = comments[i - 1];
+    if (comment && comment.type === 'Block' && comment.value.charAt(0) === '*') {
+      return comment.value.replace(LEADING_STAR, '').trim();
+    }
+  }
+}
+
+
+function resolveIdentifier(node) {
+  if (node.type !== 'Identifier') {
+    return node;
+  }
+  console.log(node);
+}

--- a/ngdoc/index.js
+++ b/ngdoc/index.js
@@ -82,7 +82,7 @@ module.exports = new Package('ngdoc', [
   });
 
   computeIdsProcessor.idTemplates.push({
-    docTypes: ['provider', 'service', 'directive', 'input', 'object', 'function', 'filter', 'type' ],
+    docTypes: ['provider', 'service', 'directive', 'input', 'object', 'function', 'filter', 'type', 'controller', 'constant'],
     idTemplate: 'module:${module}.${docType}:${name}',
     getAliases: getAliases
   });
@@ -92,7 +92,7 @@ module.exports = new Package('ngdoc', [
 
 .config(function(computePathsProcessor, createDocMessage) {
   computePathsProcessor.pathTemplates.push({
-    docTypes: ['provider', 'service', 'directive', 'input', 'object', 'function', 'filter', 'type' ],
+    docTypes: ['provider', 'service', 'directive', 'input', 'object', 'function', 'filter', 'type', 'controller', 'constant'],
     pathTemplate: '${area}/${module}/${docType}/${name}',
     outputPathTemplate: 'partials/${area}/${module}/${docType}/${name}.html'
   });

--- a/ngdoc/templates/api/constant.template.html
+++ b/ngdoc/templates/api/constant.template.html
@@ -1,0 +1,1 @@
+{% extends "api/object.template.html" %}

--- a/ngdoc/templates/api/controller.template.html
+++ b/ngdoc/templates/api/controller.template.html
@@ -1,0 +1,1 @@
+{% extends "api/object.template.html" %}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "catharsis": "^0.8.1",
     "change-case": "^2.1.0",
     "dgeni": "^0.4.0",
+    "escope": "^3.4.0",
     "espree": "^2.2.3",
     "estraverse": "^4.1.0",
     "glob": "~3.2.8",


### PR DESCRIPTION
In its current state this is not yet ready. Docs and tests are missing for example. This is basically just a code dump.

I still want to implement the following features:
- Customize handling of object properties. This can be used to:
  - Resolve factories from providers.
  - Resolve special directive properties, such as `restrict`.
- Handle functions as services, instead of just objects.

Furthermore I'd like to add the following, though it's not directly related to this feature:
- Allow to use `@description` as a default start tag. It just looks silly to start every comment with this tag with all the boilerplate removed.
- Enable linking to external projects using a standarized JSON file, similar to `objects.inv` of [intersphinx](http://www.sphinx-doc.org/en/stable/ext/intersphinx.html). Adding `@requires` for members not in the current project, causes a lot of warnings.

Of course a PR will never be complete without some issue references:
- #94
- #156
- [eslint-plugin-angular #335](https://github.com/Gillespie59/eslint-plugin-angular/issues/335)
