### PR TITLE
Fixed "Failed to parse examples - componentGroup"

### DIFF
--- a/examples/processors/examples-parse.js
+++ b/examples/processors/examples-parse.js
@@ -19,6 +19,7 @@ module.exports = function parseExamplesProcessor(log, exampleMap, trimIndentatio
 
       docs.forEach(function(doc) {
         try {
+          if (!doc.content) { return; }
           doc.content = doc.content.replace(EXAMPLE_REGEX, function processExample(match, attributeText, exampleText) {
 
             var example = extractAttributes(attributeText);


### PR DESCRIPTION
This failed in my setup: 
```
    [
        require('dgeni-packages/angularjs'),
        require('dgeni-packages/jsdoc'),
        require('dgeni-packages/ngdoc'),
        require('dgeni-packages/nunjucks'),
        require('dgeni-packages/examples')
    ]
```

Output was: 
```
    info:    running processor: readFilesProcessor
    info:    running processor: parseModulesProcessor
    info:    running processor: generateModuleDocsProcessor
    info:    running processor: extractJSDocCommentsProcessor
    info:    running processor: parseExamplesProcessor
    error:   Error: Failed to parse examples - doc "module:instant.d3.directives" (componentGroup)

    Original Error:

    TypeError: Cannot read property 'replace' of undefined
        at D:\dev\Bouvet\bouvet-instant-ng\node_modules\dgeni-packages\examples\processors\examples-parse.js:23:36
        at Array.forEach (native)
        at Object.$process (D:\dev\Bouvet\bouvet-instant-ng\node_modules\dgeni-packages\examples\processors\examples-parse.js:20:12)
        at D:\dev\Bouvet\bouvet-instant-ng\node_modules\dgeni\lib\Dgeni.js:202:28
        at _fulfilled (D:\dev\Bouvet\bouvet-instant-ng\node_modules\q\q.js:834:54)
        at self.promiseDispatch.done (D:\dev\Bouvet\bouvet-instant-ng\node_modules\q\q.js:863:30)
        at Promise.promise.promiseDispatch (D:\dev\Bouvet\bouvet-instant-ng\node_modules\q\q.js:796:13)
        at D:\dev\Bouvet\bouvet-instant-ng\node_modules\q\q.js:857:14
        at runSingle (D:\dev\Bouvet\bouvet-instant-ng\node_modules\q\q.js:137:13)
        at flush (D:\dev\Bouvet\bouvet-instant-ng\node_modules\q\q.js:125:13)
        at nextTickCallbackWith0Args (node.js:452:9)
        at process._tickCallback (node.js:381:13)
        at D:\dev\Bouvet\bouvet-instant-ng\node_modules\dgeni-packages\examples\processors\examples-parse.js:42:17
        at Array.forEach (native)
        at Object.$process (D:\dev\Bouvet\bouvet-instant-ng\node_modules\dgeni-packages\examples\processors\examples-parse.js:20:12)
        at D:\dev\Bouvet\bouvet-instant-ng\node_modules\dgeni\lib\Dgeni.js:202:28
        at _fulfilled (D:\dev\Bouvet\bouvet-instant-ng\node_modules\q\q.js:834:54)
        at self.promiseDispatch.done (D:\dev\Bouvet\bouvet-instant-ng\node_modules\q\q.js:863:30)
        at Promise.promise.promiseDispatch (D:\dev\Bouvet\bouvet-instant-ng\node_modules\q\q.js:796:13)
        at D:\dev\Bouvet\bouvet-instant-ng\node_modules\q\q.js:857:14
        at runSingle (D:\dev\Bouvet\bouvet-instant-ng\node_modules\q\q.js:137:13)
        at flush (D:\dev\Bouvet\bouvet-instant-ng\node_modules\q\q.js:125:13)
        at nextTickCallbackWith0Args (node.js:452:9)
        at process._tickCallback (node.js:381:13)
    info:    running processor: parseTagsProcessor
    info:    running processor: filterNgDocsProcessor
    info:    running processor: extractTagsProcessor
    info:    running processor: codeNameProcessor
    info:    running processor: generateExamplesProcessor
    info:    running processor: generateProtractorTestsProcessor
    info:    running processor: computeIdsProcessor
    info:    running processor: memberDocsProcessor
    info:    running processor: moduleDocsProcessor
    info:    running processor: generateComponentGroupsProcessor
    info:    running processor: providerDocsProcessor
    info:    running processor: computePathsProcessor
    info:    running processor: extendDocsProcessor
    info:    running processor: renderDocsProcessor
    info:    running processor: unescapeCommentsProcessor
    info:    running processor: inlineTagProcessor
    info:    running processor: writeFilesProcessor
    info:    running processor: checkAnchorLinksProcessor
```