### PR TITLE
remove overkill checks in jsdocs

### DIFF
--- a/jsdoc/services/transforms/extract-access.js
+++ b/jsdoc/services/transforms/extract-access.js
@@ -14,10 +14,6 @@ module.exports = function accessTagTransform(createDocMessage, log) {
    * @param {String} tag value
    */
   function transformAccess (doc, tag, value) {
-    if ( !(doc.docType === 'property' || doc.docType === 'method') ) {
-      throw new Error(createDocMessage('"@'+ tag.tagDef.name +'" tag found on @'+ doc.docType +' document while defined for @property and @method only', doc));
-    }
-
     if (tag.tagDef.name != 'access' && tag.tagDef.docProperty != 'access') {
         throw new Error(createDocMessage('Tag @' + tag.tagDef.name + ' does not fill up doc.access property', doc));
     }


### PR DESCRIPTION
This is a replacement/follow-up pull request from https://github.com/angular/dgeni-packages/pull/169

@petebacondarwin commented on the fact that there are jsdoc checks which encumber the developer using the library.