### PR TITLE
Codename extraction refactored

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ the value of the tag from the string in the tag description to something more me
 * `trimWhitespaceTransform` - trim whitespace from before and after the tag value
 * `unknownTagTransform` - add an error to the tag if it is unknown
 * `wholeTagTransform` - Use the whole tag as the value rather than using a tag property
+* `codeNameService` - helper service for `codeNameProcessor`, registers code name matchers and performs
+ actual matches against AST tree
 
 ### Templates
 
@@ -152,6 +154,38 @@ the value of the tag from the string in the tag description to something more me
 
 This package provides a minimal implementation of tags from the JSDoc project. They extract the name
 and type from the tag description accordingly but do not fully implement all the JSDoc tag functionality.
+
+### Code Name Matchers
+Matcher performs a search for a suitable code name at the given jsdoc code point (AST node).
+`codeNameService` matches AST node name against matcher name and if suitable matcher is found, executes it.
+
+Matcher name consists of `<AstNodeName>` and `NodeMatcher` substrings, i.e. `FunctionExpressionNodeMatcher`
+then latter is stripped and matcher is used by the former part, i.e. `FunctionExpression`.
+
+Matcher should accept single argument - node and return either string with name or literal `null`.
+
+Matchers:
+* `ArrayExpression`
+* `ArrowFunctionExpression`
+* `AssignmentExpression`
+* `CallExpression`
+* `ClassDeclaration`
+* `ExportDefaultDeclaration`
+* `ExpressionStatement`
+* `FunctionDeclaration`
+* `FunctionExpression`
+* `Identifier`
+* `Literal`
+* `MemberExpression`
+* `MethodDefinition`
+* `NewExpression`
+* `ObjectExpression`
+* `Program`
+* `Property`
+* `ReturnStatement`
+* `ThrowStatement`
+* `VariableDeclaration`
+* `VariableDeclarator`
 
 ## `ngdoc` Package
 
@@ -203,7 +237,6 @@ HTML anchors
 * `getLinkInfo()` - Get link information to a document that matches the given url
 * `getTypeClass()` - Get a CSS class string for the given type string
 * `moduleMap` - A collection of modules keyed on the module id
-
 
 ### Templates
 

--- a/jsdoc/index.js
+++ b/jsdoc/index.js
@@ -20,7 +20,8 @@ module.exports = new Package('jsdoc', [require('../base')])
 .processor(require('./processors/extract-tags'))
 .processor(require('./processors/inline-tags'))
 
-
+.factory(require('./services/code-name-map'))
+.factory(require('./services/code-name'))
 .factory(require('./services/transforms/extract-access'))
 .factory(require('./services/transforms/extract-name'))
 .factory(require('./services/transforms/extract-type'))
@@ -70,4 +71,8 @@ module.exports = new Package('jsdoc', [require('../base')])
     pathTemplate: '${id}',
     outputPathTemplate: '${path}.html'
   });
+})
+
+.config(function(codeNameService, getInjectables) {
+  codeNameService.matchers = getInjectables(require('./services/code-name-matchers'));
 });

--- a/jsdoc/processors/code-name.js
+++ b/jsdoc/processors/code-name.js
@@ -2,13 +2,13 @@
  * @dgProcessor codeNameProcessor
  * @description  Infer the name of the document from name of the following code
  */
-module.exports = function codeNameProcessor(log) {
+module.exports = function codeNameProcessor(log, codeNameService) {
   return {
     $runAfter: ['files-read'],
     $runBefore: ['processing-docs'],
     $process: function(docs) {
       docs.forEach(function(doc) {
-        doc.codeName = doc.codeName || (doc.codeNode && findCodeName(doc.codeNode));
+        doc.codeName = doc.codeName || (doc.codeNode && codeNameService.find(doc.codeNode)) || null;
         if ( doc.codeName ) {
           log.silly('found codeName: ', doc.codeName);
         }
@@ -16,55 +16,4 @@ module.exports = function codeNameProcessor(log) {
       return docs;
     }
   };
-
-  /**
-   * Recurse down the code AST node that is associated with this doc for a name
-   * @param  {Object} node The JS AST node information for the code to find the name of
-   * @return {String}      The name of the code or null if none found.
-   */
-  function findCodeName(node) {
-    var match;
-    switch(node.type) {
-      case 'FunctionDeclaration':
-        return node.id && node.id.name;
-      case 'ExpressionStatement':
-        return findCodeName(node.expression);
-      case 'AssignmentExpression':
-        return findCodeName(node.right) || findCodeName(node.left);
-      case 'FunctionExpression':
-        return node.id && node.id.name;
-      case 'MemberExpression':
-        return findCodeName(node.property);
-      case 'CallExpression':
-        return findCodeName(node.callee);
-      case 'Identifier':
-        return node.name;
-      case 'ReturnStatement':
-        return findCodeName(node.argument);
-      case 'Property':
-        return findCodeName(node.value) || findCodeName(node.key);
-      case 'ObjectExpression':
-        return null;
-      case 'ArrayExpression':
-        return null;
-      case 'Literal':
-        return node.value;
-      case 'Program':
-        return node.body[0] ? findCodeName(node.body[0]) : null;
-      case 'VariableDeclaration':
-        return findCodeName(node.declarations[0]);
-      case 'VariableDeclarator':
-        return node.id && node.id.name;
-      case 'ExportDefaultDeclaration':
-        return null;
-      case 'MethodDefinition':
-        return findCodeName(node.key);
-      case 'ArrowFunctionExpression':
-        return null;
-      default:
-        log.warn('HELP! Unrecognised node type: ' + node.type);
-        log.warn(node);
-        return null;
-    }
-  }
 };

--- a/jsdoc/services/code-name-map.js
+++ b/jsdoc/services/code-name-map.js
@@ -1,0 +1,10 @@
+var StringMap = require('stringmap');
+
+/**
+ * @dgService codeNameMap
+ * @description
+ * A map of AST codeName matchers
+ */
+module.exports = function codeNameMap() {
+  return new StringMap();
+};

--- a/jsdoc/services/code-name-matchers/array-expression.js
+++ b/jsdoc/services/code-name-matchers/array-expression.js
@@ -1,0 +1,13 @@
+/**
+ * @dgService ArrayExpressionNodeMatcher
+ * @description Creates code name matcher for AST entry
+ */
+module.exports = function ArrayExpressionNodeMatcherFactory () {
+  /**
+   * @param {Node} node AST node to process
+   * @returns {String|Null} code name from node
+   */
+  return function ArrayExpressionNodeMatcher (node) {
+    return null;
+  }
+};

--- a/jsdoc/services/code-name-matchers/array-expression.spec.js
+++ b/jsdoc/services/code-name-matchers/array-expression.spec.js
@@ -1,0 +1,16 @@
+var matcherFactory = require('./array-expression');
+
+describe('ArrayExpression matcher', function() {
+
+  var matcher;
+
+  beforeEach(function() {
+    matcher = matcherFactory();
+  });
+
+  it("should return null for any argument", function() {
+    expect(matcher()).toBeNull();
+    expect(matcher(null)).toBeNull();
+    expect(matcher({})).toBeNull();
+  });
+});

--- a/jsdoc/services/code-name-matchers/arrow-function-expression.js
+++ b/jsdoc/services/code-name-matchers/arrow-function-expression.js
@@ -1,0 +1,13 @@
+/**
+ * @dgService ArrowFunctionExpressionNodeMatcher
+ * @returns {String|Null} code name from node
+ */
+module.exports = function ArrowFunctionExpressionNodeMatcherFactory () {
+  /**
+   * @param {Node} node AST node to process
+   * @returns {String|Null} code name from node
+   */
+  return function ArrowFunctionExpressionNodeMatcher (node) {
+    return null;
+  }
+};

--- a/jsdoc/services/code-name-matchers/arrow-function-expression.spec.js
+++ b/jsdoc/services/code-name-matchers/arrow-function-expression.spec.js
@@ -1,0 +1,16 @@
+var matcherFactory = require('./arrow-function-expression');
+
+describe('ArrowFunctionExpression matcher', function() {
+
+  var matcher;
+
+  beforeEach(function() {
+    matcher = matcherFactory();
+  });
+
+  it("should return null for any argument", function() {
+    expect(matcher()).toBeNull();
+    expect(matcher(null)).toBeNull();
+    expect(matcher({})).toBeNull();
+  });
+});

--- a/jsdoc/services/code-name-matchers/assignment-expression.js
+++ b/jsdoc/services/code-name-matchers/assignment-expression.js
@@ -1,0 +1,13 @@
+/**
+ * @dgService AssignmentExpressionNodeMatcher
+ * @returns {String|Null} code name from node
+ */
+module.exports = function AssignmentExpressionNodeMatcherFactory (codeNameService) {
+  /**
+   * @param {Node} node AST node to process
+   * @returns {String|Null} code name from node
+   */
+  return function AssignmentExpressionNodeMatcher (node) {
+    return codeNameService.find(node.right) || codeNameService.find(node.left) || null;
+  }
+};

--- a/jsdoc/services/code-name-matchers/assignment-expression.spec.js
+++ b/jsdoc/services/code-name-matchers/assignment-expression.spec.js
@@ -1,0 +1,56 @@
+var matcherFactory = require('./assignment-expression');
+
+describe('AssignmentExpression matcher', function() {
+
+  var matcher, codeNameServiceMock;
+
+  beforeEach(function() {
+    codeNameServiceMock = {
+      find: function (arg) {
+        return arg;
+      }
+    };
+    matcher = matcherFactory(codeNameServiceMock);
+  });
+
+  it("should start search for right", function () {
+    var expr = {
+      left: 'left',
+      right: 'right'
+    };
+
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher(expr)).toEqual(expr.right);
+    expect(codeNameServiceMock.find.calls.count()).toEqual(1);
+    expect(codeNameServiceMock.find).toHaveBeenCalledWith(expr.right);
+  });
+
+  it("should continue search with left", function () {
+    codeNameServiceMock.value = null;
+    var expr = {
+      left: 'test',
+      right: null
+    };
+
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher(expr)).toEqual(expr.left);
+    expect(codeNameServiceMock.find.calls.count()).toEqual(2);
+    expect(codeNameServiceMock.find.calls.allArgs()).toEqual([[null],[expr.left]]);
+  });
+
+  it("should return null for empty left and right", function () {
+    codeNameServiceMock.value = null;
+    var expr = {
+      left: null,
+      right: null
+    };
+
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher(expr)).toBeNull();
+    expect(codeNameServiceMock.find.calls.count()).toEqual(2);
+    expect(codeNameServiceMock.find.calls.allArgs()).toEqual([[null],[null]]);
+  });
+});

--- a/jsdoc/services/code-name-matchers/call-expression.js
+++ b/jsdoc/services/code-name-matchers/call-expression.js
@@ -1,0 +1,13 @@
+/**
+ * @dgService CallExpressionNodeMatcher
+ * @returns {String|Null} code name from node
+ */
+module.exports = function CallExpressionNodeMatcherFactory (codeNameService) {
+  /**
+   * @param {Node} node AST node to process
+   * @returns {String|Null} code name from node
+   */
+  return function CallExpressionNodeMatcher (node) {
+    return codeNameService.find(node.callee) || null;
+  }
+};

--- a/jsdoc/services/code-name-matchers/call-expression.spec.js
+++ b/jsdoc/services/code-name-matchers/call-expression.spec.js
@@ -1,0 +1,30 @@
+var matcherFactory = require('./call-expression');
+
+describe('CallExpression matcher', function() {
+
+  var matcher, codeNameServiceMock;
+
+  beforeEach(function() {
+    codeNameServiceMock = {
+      find: function (arg) {
+        return arg;
+      }
+    };
+    matcher = matcherFactory(codeNameServiceMock);
+  });
+
+  it("should return null for unsupported node", function() {
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher({})).toBeNull();
+    expect(matcher({callee: null})).toBeNull();
+    expect(codeNameServiceMock.find.calls.count()).toEqual(2);
+  });
+
+  it("should return name for supported node", function() {
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher({callee: 'test'})).toEqual('test');
+    expect(codeNameServiceMock.find.calls.count()).toEqual(1);
+  });
+});

--- a/jsdoc/services/code-name-matchers/class-declaration.js
+++ b/jsdoc/services/code-name-matchers/class-declaration.js
@@ -1,0 +1,13 @@
+/**
+ * @dgService ClassDeclarationNodeMatcher
+ * @returns {String|Null} code name from node
+ */
+module.exports = function FunctionDeclarationNodeMatcherFactory () {
+  /**
+   * @param {Node} node AST node to process
+   * @returns {String|Null} code name from node
+   */
+  return function ClassDeclarationNodeMatcher (node) {
+    return node.id && node.id.name || null;
+  }
+};

--- a/jsdoc/services/code-name-matchers/class-declaration.spec.js
+++ b/jsdoc/services/code-name-matchers/class-declaration.spec.js
@@ -1,0 +1,21 @@
+var matcherFactory = require('./class-declaration');
+
+describe('ClassDeclaration matcher', function() {
+
+  var matcher;
+
+  beforeEach(function() {
+    matcher = matcherFactory();
+  });
+
+  it("should return null for unsupported node", function() {
+    expect(matcher({id: null})).toBeNull();
+    expect(matcher({id: {}})).toBeNull();
+    expect(matcher({id: {name: null}})).toBeNull();
+    expect(matcher({id: {name: ""}})).toBeNull();
+  });
+
+  it("should return name for supported node", function() {
+    expect(matcher({id: {name: "test"}})).toEqual("test");
+  });  
+});

--- a/jsdoc/services/code-name-matchers/export-default-declaration.js
+++ b/jsdoc/services/code-name-matchers/export-default-declaration.js
@@ -1,0 +1,13 @@
+/**
+ * @dgService ExportDefaultDeclarationNodeMatcher
+ * @returns {String|Null} code name from node
+ */
+module.exports = function ExportDefaultDeclarationNodeMatcherFactory (codeNameService) {
+  /**
+   * @param {Node} node AST node to process
+   * @returns {String|Null} code name from node
+   */
+  return function ExportDefaultDeclarationNodeMatcher (node) {
+    return null;
+  }
+};

--- a/jsdoc/services/code-name-matchers/export-default-declaration.spec.js
+++ b/jsdoc/services/code-name-matchers/export-default-declaration.spec.js
@@ -1,0 +1,14 @@
+var matcherFactory = require('./export-default-declaration');
+
+describe('ExportDefaultDeclaration matcher', function() {
+
+  var matcher;
+
+  beforeEach(function() {
+    matcher = matcherFactory();
+  });
+
+  it("should return null for any argument", function() {
+    expect(matcher({})).toBeNull();
+  });
+});

--- a/jsdoc/services/code-name-matchers/expression-statement.js
+++ b/jsdoc/services/code-name-matchers/expression-statement.js
@@ -1,0 +1,13 @@
+/**
+ * @dgService ExpressionStatementNodeMatcher
+ * @returns {String|Null} code name from node
+ */
+module.exports = function ExpressionStatementNodeMatcherFactory (codeNameService) {
+  /**
+   * @param {Node} node AST node to process
+   * @returns {String|Null} code name from node
+   */
+  return function ExpressionStatementNodeMatcher (node) {
+    return codeNameService.find(node.expression) || null;
+  }
+};

--- a/jsdoc/services/code-name-matchers/expression-statement.spec.js
+++ b/jsdoc/services/code-name-matchers/expression-statement.spec.js
@@ -1,0 +1,30 @@
+var matcherFactory = require('./expression-statement');
+
+describe('ExpressionStatement matcher', function() {
+
+  var matcher, codeNameServiceMock;
+
+  beforeEach(function() {
+    codeNameServiceMock = {
+      find: function (arg) {
+        return arg;
+      }
+    };
+    matcher = matcherFactory(codeNameServiceMock);
+  });
+
+  it("should return null for unsupported node", function() {
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher({})).toBeNull();
+    expect(matcher({expression: null})).toBeNull();
+    expect(codeNameServiceMock.find.calls.count()).toEqual(2);
+  });
+
+  it("should return name for supported node", function() {
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher({expression: 'test'})).toEqual('test');
+    expect(codeNameServiceMock.find.calls.count()).toEqual(1);
+  });
+});

--- a/jsdoc/services/code-name-matchers/function-declaration.js
+++ b/jsdoc/services/code-name-matchers/function-declaration.js
@@ -1,0 +1,13 @@
+/**
+ * @dgService FunctionDeclarationNodeMatcher
+ * @returns {String|Null} code name from node
+ */
+module.exports = function FunctionDeclarationNodeMatcherFactory () {
+  /**
+   * @param {Node} node AST node to process
+   * @returns {String|Null} code name from node
+   */
+  return function FunctionDeclarationNodeMatcher (node) {
+    return node.id && node.id.name || null;
+  }
+};

--- a/jsdoc/services/code-name-matchers/function-declaration.spec.js
+++ b/jsdoc/services/code-name-matchers/function-declaration.spec.js
@@ -1,0 +1,21 @@
+var matcherFactory = require('./function-declaration');
+
+describe('FunctionDeclaration matcher', function() {
+
+  var matcher;
+
+  beforeEach(function() {
+    matcher = matcherFactory();
+  });
+
+  it("should return null for unsupported node", function() {
+    expect(matcher({id: null})).toBeNull();
+    expect(matcher({id: {}})).toBeNull();
+    expect(matcher({id: {name: null}})).toBeNull();
+    expect(matcher({id: {name: ""}})).toBeNull();
+  });
+
+  it("should return name for supported node", function() {
+    expect(matcher({id: {name: "test"}})).toEqual("test");
+  });  
+});

--- a/jsdoc/services/code-name-matchers/function-expression.js
+++ b/jsdoc/services/code-name-matchers/function-expression.js
@@ -1,0 +1,13 @@
+/**
+ * @dgService FunctionExpressionNodeMatcher
+ * @returns {String|Null} code name from node
+ */
+module.exports = function FunctionExpressionNodeMatcherFactory () {
+  /**
+   * @param {Node} node AST node to process
+   * @returns {String|Null} code name from node
+   */
+  return function FunctionExpressionNodeMatcher (node) {
+    return node.id && node.id.name || null;
+  }
+};

--- a/jsdoc/services/code-name-matchers/function-expression.spec.js
+++ b/jsdoc/services/code-name-matchers/function-expression.spec.js
@@ -1,0 +1,21 @@
+var matcherFactory = require('./function-expression');
+
+describe('FunctionExpression matcher', function() {
+
+  var matcher;
+
+  beforeEach(function() {
+    matcher = matcherFactory();
+  });
+  
+  it("should return null for unsupported node", function() {
+    expect(matcher({id: null})).toBeNull();
+    expect(matcher({id: {}})).toBeNull();
+    expect(matcher({id: {name: null}})).toBeNull();
+    expect(matcher({id: {name: ""}})).toBeNull();
+  });
+
+  it("should return name for supported node", function() {
+    expect(matcher({id: {name: "test"}})).toEqual("test");
+  });  
+});

--- a/jsdoc/services/code-name-matchers/identifier.js
+++ b/jsdoc/services/code-name-matchers/identifier.js
@@ -1,0 +1,13 @@
+/**
+ * @dgService IdentifierNodeMatcher
+ * @description Creates code name matcher for AST entry
+ */
+module.exports = function IdentifierNodeMatcherFactory () {
+  /**
+   * @param {Node} node AST node to process
+   * @returns {String|Null} code name from node
+   */
+  return function IdentifierNodeMatcher (node) {
+    return node.name || null;
+  }
+};

--- a/jsdoc/services/code-name-matchers/identifier.spec.js
+++ b/jsdoc/services/code-name-matchers/identifier.spec.js
@@ -1,0 +1,19 @@
+var matcherFactory = require('./identifier');
+
+describe('Identifier matcher', function() {
+
+  var matcher;
+
+  beforeEach(function() {
+    matcher = matcherFactory();
+  });
+
+  it("should return null for unsupported node", function() {
+    expect(matcher({})).toBeNull();
+    expect(matcher({foo: "bar"})).toBeNull();
+  });
+
+  it("should return name for supported node", function() {
+    expect(matcher({name: "test"})).toEqual("test");
+  });
+});

--- a/jsdoc/services/code-name-matchers/index.js
+++ b/jsdoc/services/code-name-matchers/index.js
@@ -1,0 +1,23 @@
+module.exports = [
+  require('./array-expression.js'),
+  require('./arrow-function-expression.js'),
+  require('./assignment-expression.js'),
+  require('./call-expression.js'),
+  require('./class-declaration.js'),
+  require('./export-default-declaration.js'),
+  require('./expression-statement.js'),
+  require('./function-declaration.js'),
+  require('./function-expression.js'),
+  require('./identifier.js'),
+  require('./literal.js'),
+  require('./member-expression.js'),
+  require('./method-definition.js'),
+  require('./new-expression.js'),
+  require('./object-expression.js'),
+  require('./program.js'),
+  require('./property.js'),
+  require('./return-statement.js'),
+  require('./throw-statement.js'),
+  require('./variable-declaration.js'),
+  require('./variable-declarator.js')
+];

--- a/jsdoc/services/code-name-matchers/literal.js
+++ b/jsdoc/services/code-name-matchers/literal.js
@@ -1,0 +1,13 @@
+/**
+ * @dgService LiteralNodeMatcher
+ * @description Returns code name from node
+ */
+module.exports = function LiteralNodeMatcherFactory () {
+  /**
+   * @param {Node} node AST node to process
+   * @returns {String|Null} code name from node
+   */
+  return function LiteralNodeMatcher (node) {
+    return node.value || null;
+  }
+};

--- a/jsdoc/services/code-name-matchers/literal.spec.js
+++ b/jsdoc/services/code-name-matchers/literal.spec.js
@@ -1,0 +1,20 @@
+var matcherFactory = require('./literal');
+
+describe('Literal matcher', function() {
+
+  var matcher;
+
+  beforeEach(function() {
+    matcher = matcherFactory();
+  });
+
+  it("should return null for unsupported node", function() {
+    expect(matcher({})).toBeNull();
+    expect(matcher({value: null})).toBeNull();
+    expect(matcher({value: ""})).toBeNull();
+  });
+
+  it("should return name for supported node", function() {
+    expect(matcher({value: "test"})).toEqual("test");
+  });
+});

--- a/jsdoc/services/code-name-matchers/member-expression.js
+++ b/jsdoc/services/code-name-matchers/member-expression.js
@@ -1,0 +1,13 @@
+/**
+ * @dgService MemberExpressionNodeMatcher
+ * @description Returns code name from node
+ */
+module.exports = function MemberExpressionNodeMatcherFactory (codeNameService) {
+  /**
+   * @param {Node} node AST node to process
+   * @returns {String|Null} code name from node
+   */
+  return function MemberExpressionNodeMatcher (node) {
+    return codeNameService.find(node.property) || null;
+  }
+};

--- a/jsdoc/services/code-name-matchers/member-expression.spec.js
+++ b/jsdoc/services/code-name-matchers/member-expression.spec.js
@@ -1,0 +1,29 @@
+var matcherFactory = require('./member-expression');
+
+describe('MemberExpression matcher', function() {
+
+  var matcher, codeNameServiceMock;
+
+  beforeEach(function() {
+    codeNameServiceMock = {
+      find: function (arg) {
+        return arg;
+      }
+    };
+    matcher = matcherFactory(codeNameServiceMock);
+  });
+
+  it("should return null for unsupported node", function() {
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher({})).toBeNull();
+    expect(codeNameServiceMock.find.calls.count()).toEqual(1);
+  });
+
+  it("should return name for supported node", function() {
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher({property: 'test'})).toEqual('test');
+    expect(codeNameServiceMock.find.calls.count()).toEqual(1);
+  });  
+});

--- a/jsdoc/services/code-name-matchers/method-definition.js
+++ b/jsdoc/services/code-name-matchers/method-definition.js
@@ -1,0 +1,13 @@
+/**
+ * @dgService MethodDefinitionNodeMatcher
+ * @description Returns code name from node
+ */
+module.exports = function MethodDefinitionNodeMatcherFactory (codeNameService) {
+  /**
+   * @param {Node} node AST node to process
+   * @returns {String|Null} code name from node
+   */
+  return function MethodDefinitionNodeMatcher (node) {
+    return codeNameService.find(node.key) || null;
+  }
+};

--- a/jsdoc/services/code-name-matchers/method-definition.spec.js
+++ b/jsdoc/services/code-name-matchers/method-definition.spec.js
@@ -1,0 +1,29 @@
+var matcherFactory = require('./method-definition');
+
+describe('MethodDefinition matcher', function() {
+
+  var matcher, codeNameServiceMock;
+
+  beforeEach(function() {
+    codeNameServiceMock = {
+      find: function (arg) {
+        return arg;
+      }
+    };
+    matcher = matcherFactory(codeNameServiceMock);
+  });
+
+  it("should return null for unsupported node", function() {
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher({})).toBeNull();
+    expect(codeNameServiceMock.find.calls.count()).toEqual(1);
+  });
+
+  it("should return name for supported node", function() {
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher({key: 'test'})).toEqual('test');
+    expect(codeNameServiceMock.find.calls.count()).toEqual(1);
+  });  
+});

--- a/jsdoc/services/code-name-matchers/new-expression.js
+++ b/jsdoc/services/code-name-matchers/new-expression.js
@@ -1,0 +1,13 @@
+/**
+ * @dgService NewExpressionNodeMatcher
+ * @description Returns code name from node
+ */
+module.exports = function NewExpressionNodeMatcherFactory (codeNameService) {
+  /**
+   * @param {Node} node AST node to process
+   * @returns {String|Null} code name from node
+   */
+  return function NewExpressionNodeMatcher (node) {
+    return codeNameService.find(node.callee) || null;
+  }
+};

--- a/jsdoc/services/code-name-matchers/new-expression.spec.js
+++ b/jsdoc/services/code-name-matchers/new-expression.spec.js
@@ -1,0 +1,29 @@
+var matcherFactory = require('./new-expression');
+
+describe('NewExpression matcher', function() {
+
+  var matcher, codeNameServiceMock;
+
+  beforeEach(function() {
+    codeNameServiceMock = {
+      find: function (arg) {
+        return arg;
+      }
+    };
+    matcher = matcherFactory(codeNameServiceMock);
+  });
+
+  it("should return null for unsupported node", function() {
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher({})).toBeNull();
+    expect(codeNameServiceMock.find.calls.count()).toEqual(1);
+  });
+
+  it("should return name for supported node", function() {
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher({callee: 'test'})).toEqual('test');
+    expect(codeNameServiceMock.find.calls.count()).toEqual(1);
+  }); 
+});

--- a/jsdoc/services/code-name-matchers/object-expression.js
+++ b/jsdoc/services/code-name-matchers/object-expression.js
@@ -1,0 +1,13 @@
+/**
+ * @dgService ObjectExpressionNodeMatcher
+ * @description Returns code name from node
+ */
+module.exports = function ObjectExpressionNodeMatcherFactory () {
+  /**
+   * @param {Node} node AST node to process
+   * @returns {String|Null} code name from node
+   */
+  return function ObjectExpressionNodeMatcher (node) {
+    return null;
+  }
+};

--- a/jsdoc/services/code-name-matchers/object-expression.spec.js
+++ b/jsdoc/services/code-name-matchers/object-expression.spec.js
@@ -1,0 +1,16 @@
+var matcherFactory = require('./object-expression');
+
+describe('ObjectExpression matcher', function() {
+
+  var matcher;
+
+  beforeEach(function() {
+    matcher = matcherFactory();
+  });
+
+  it("should return null for any argument", function() {
+    expect(matcher()).toBeNull();
+    expect(matcher(null)).toBeNull();
+    expect(matcher({})).toBeNull();
+  });
+});

--- a/jsdoc/services/code-name-matchers/program.js
+++ b/jsdoc/services/code-name-matchers/program.js
@@ -1,0 +1,13 @@
+/**
+ * @dgService ProgramNodeMatcher
+ * @description Returns code name from node
+ */
+module.exports = function ProgramNodeMatcherFactory (codeNameService) {
+  /**
+   * @param {Node} node AST node to process
+   * @returns {String|Null} code name from node
+   */
+  return function ProgramNodeMatcher (node) {
+    return node.body && node.body[0] && codeNameService.find(node.body[0]) || null;
+  }
+};

--- a/jsdoc/services/code-name-matchers/program.spec.js
+++ b/jsdoc/services/code-name-matchers/program.spec.js
@@ -1,0 +1,32 @@
+var matcherFactory = require('./program');
+
+describe('Program matcher', function() {
+
+  var matcher, codeNameServiceMock;
+
+  beforeEach(function() {
+    codeNameServiceMock = {
+      find: function (arg) {
+        return arg;
+      }
+    };
+    matcher = matcherFactory(codeNameServiceMock);
+  });
+
+  it("should return null for unsupported node", function() {
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher({})).toBeNull();
+    expect(matcher({body: null})).toBeNull();
+    expect(matcher({body: []})).toBeNull();
+    expect(matcher({body: [null, "test"]})).toBeNull();
+    expect(codeNameServiceMock.find.calls.count()).toEqual(0);
+  });
+
+  it("should return name for supported node", function() {
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher({body: ["test"]})).toEqual("test");
+    expect(codeNameServiceMock.find.calls.count()).toEqual(1);
+  });  
+});

--- a/jsdoc/services/code-name-matchers/property.js
+++ b/jsdoc/services/code-name-matchers/property.js
@@ -1,0 +1,13 @@
+/**
+ * @dgService PropertyNodeMatcher
+ * @description Returns code name from node
+ */
+module.exports = function PropertyNodeMatcherFactory (codeNameService) {
+  /**
+   * @param {Node} node AST node to process
+   * @returns {String|Null} code name from node
+   */
+  return function PropertyNodeMatcher (node) {
+    return codeNameService.find(node.value) || codeNameService.find(node.key);
+  }
+};

--- a/jsdoc/services/code-name-matchers/property.spec.js
+++ b/jsdoc/services/code-name-matchers/property.spec.js
@@ -1,0 +1,56 @@
+var matcherFactory = require('./property');
+
+describe('Property matcher', function() {
+
+  var matcher, codeNameServiceMock;
+
+  beforeEach(function() {
+    codeNameServiceMock = {
+      find: function (arg) {
+        return arg;
+      }
+    };
+    matcher = matcherFactory(codeNameServiceMock);
+  });
+
+  it("should start search for value", function () {
+    var expr = {
+      key: 'key',
+      value: 'value'
+    };
+
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher(expr)).toEqual(expr.value);
+    expect(codeNameServiceMock.find.calls.count()).toEqual(1);
+    expect(codeNameServiceMock.find).toHaveBeenCalledWith(expr.value);
+  });
+
+  it("should continue search with key", function () {
+    codeNameServiceMock.value = null;
+    var expr = {
+      key: 'key',
+      value: null
+    };
+
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher(expr)).toEqual(expr.key);
+    expect(codeNameServiceMock.find.calls.count()).toEqual(2);
+    expect(codeNameServiceMock.find.calls.allArgs()).toEqual([[null],[expr.key]]);
+  });
+
+  it("should return null for empty key and value", function () {
+    codeNameServiceMock.value = null;
+    var expr = {
+      key: null,
+      value: null
+    };
+
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher(expr)).toBeNull();
+    expect(codeNameServiceMock.find.calls.count()).toEqual(2);
+    expect(codeNameServiceMock.find.calls.allArgs()).toEqual([[null],[null]]);
+  });
+});

--- a/jsdoc/services/code-name-matchers/return-statement.js
+++ b/jsdoc/services/code-name-matchers/return-statement.js
@@ -1,0 +1,13 @@
+/**
+ * @dgService ReturnStatementNodeMatcher
+ * @description Returns code name from node
+ */
+module.exports = function ReturnStatementNodeMatcherFactory (codeNameService) {
+  /**
+   * @param {Node} node AST node to process
+   * @returns {String|Null} code name from node
+   */
+  return function ReturnStatementNodeMatcher (node) {
+    return codeNameService.find(node.argument) || null;
+  }
+};

--- a/jsdoc/services/code-name-matchers/return-statement.spec.js
+++ b/jsdoc/services/code-name-matchers/return-statement.spec.js
@@ -1,0 +1,30 @@
+var matcherFactory = require('./return-statement');
+
+describe('ReturnStatement matcher', function() {
+
+  var matcher, codeNameServiceMock;
+
+  beforeEach(function() {
+    codeNameServiceMock = {
+      find: function (arg) {
+        return arg;
+      }
+    };
+    matcher = matcherFactory(codeNameServiceMock);
+  });
+
+  it("should return null for unsupported node", function() {
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher({})).toBeNull();
+    expect(matcher({argument: null})).toBeNull();    
+    expect(codeNameServiceMock.find.calls.count()).toEqual(2);
+  });
+
+  it("should return name for supported node", function() {
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher({argument: 'test'})).toEqual('test');
+    expect(codeNameServiceMock.find.calls.count()).toEqual(1);
+  });  
+});

--- a/jsdoc/services/code-name-matchers/throw-statement.js
+++ b/jsdoc/services/code-name-matchers/throw-statement.js
@@ -1,0 +1,13 @@
+/**
+ * @dgService ThrowStatementNodeMatcher
+ * @description Returns code name from node
+ */
+module.exports = function ThrowStatementNodeMatcherFactory (codeNameService) {
+  /**
+   * @param {Node} node AST node to process
+   * @returns {String|Null} code name from node
+   */
+  return function ThrowStatementNodeMatcher (node) {
+    return codeNameService.find(node.argument) || null;
+  }
+};

--- a/jsdoc/services/code-name-matchers/throw-statement.spec.js
+++ b/jsdoc/services/code-name-matchers/throw-statement.spec.js
@@ -1,0 +1,30 @@
+var matcherFactory = require('./throw-statement');
+
+describe('ThrowStatement matcher', function() {
+
+  var matcher, codeNameServiceMock;
+
+  beforeEach(function() {
+    codeNameServiceMock = {
+      find: function (arg) {
+        return arg;
+      }
+    };
+    matcher = matcherFactory(codeNameServiceMock);
+  });
+
+  it("should return null for unsupported node", function() {
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher({})).toBeNull();
+    expect(matcher({argument: null})).toBeNull();    
+    expect(codeNameServiceMock.find.calls.count()).toEqual(2);
+  });
+
+  it("should return name for supported node", function() {
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher({argument: 'test'})).toEqual('test');
+    expect(codeNameServiceMock.find.calls.count()).toEqual(1);
+  });  
+});

--- a/jsdoc/services/code-name-matchers/variable-declaration.js
+++ b/jsdoc/services/code-name-matchers/variable-declaration.js
@@ -1,0 +1,13 @@
+/**
+ * @dgService VariableDeclarationNodeMatcher
+ * @description Returns code name from node
+ */
+module.exports = function VariableDeclarationNodeMatcherFactory (codeNameService) {
+  /**
+   * @param {Node} node AST node to process
+   * @returns {String|Null} code name from node
+   */
+  return function VariableDeclarationNodeMatcher (node) {
+    return node.declarations && node.declarations[0] && codeNameService.find(node.declarations[0]) || null;
+  }
+};

--- a/jsdoc/services/code-name-matchers/variable-declaration.spec.js
+++ b/jsdoc/services/code-name-matchers/variable-declaration.spec.js
@@ -1,0 +1,32 @@
+var matcherFactory = require('./variable-declaration');
+
+describe('VariableDeclaration matcher', function() {
+
+  var matcher, codeNameServiceMock;
+
+  beforeEach(function() {
+    codeNameServiceMock = {
+      find: function (arg) {
+        return arg;
+      }
+    };
+    matcher = matcherFactory(codeNameServiceMock);
+  });
+  
+  it("should return null for unsupported node", function() {
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher({})).toBeNull();
+    expect(matcher({declarations: null})).toBeNull();
+    expect(matcher({declarations: []})).toBeNull();
+    expect(matcher({declarations: [null, "test"]})).toBeNull();
+    expect(codeNameServiceMock.find.calls.count()).toEqual(0);
+  });
+
+  it("should return name for supported node", function() {
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher({declarations: ["test"]})).toEqual("test");
+    expect(codeNameServiceMock.find.calls.count()).toEqual(1);
+  }); 
+});

--- a/jsdoc/services/code-name-matchers/variable-declarator.js
+++ b/jsdoc/services/code-name-matchers/variable-declarator.js
@@ -1,0 +1,13 @@
+/**
+ * @dgService VariableDeclaratorNodeMatcher
+ * @description Returns code name from node
+ */
+module.exports = function VariableDeclaratorNodeMatcherFactory () {
+  /**
+   * @param {Node} node AST node to process
+   * @returns {String|Null} code name from node
+   */
+  return function VariableDeclaratorNodeMatcher (node) {
+    return node.id && node.id.name || null;
+  }
+};

--- a/jsdoc/services/code-name-matchers/variable-declarator.spec.js
+++ b/jsdoc/services/code-name-matchers/variable-declarator.spec.js
@@ -1,0 +1,21 @@
+var matcherFactory = require('./variable-declarator');
+
+describe('VariableDeclarator matcher', function() {
+
+  var matcher;
+
+  beforeEach(function() {
+    matcher = matcherFactory();
+  });
+
+  it("should return null for unsupported node", function() {
+    expect(matcher({id: null})).toBeNull();
+    expect(matcher({id: {}})).toBeNull();
+    expect(matcher({id: {name: null}})).toBeNull();
+    expect(matcher({id: {name: ""}})).toBeNull();
+  });
+
+  it("should return name for supported node", function() {
+    expect(matcher({id: {name: "test"}})).toEqual("test");
+  });  
+});

--- a/jsdoc/services/code-name.js
+++ b/jsdoc/services/code-name.js
@@ -1,0 +1,54 @@
+/**
+ * @dgProcessor codeNameService
+ * @description  Infer the name of the document from name of the following code
+ */
+module.exports = function codeNameService(log, codeNameMap, getInjectables) {
+  var REMOVE_SUFFIX_REGEX = /NodeMatcher$/;
+
+  /**
+   * Registers code name mappers
+   * @param {Function|Function[]}
+   */
+  function registerCodeNameMatcher (list) {
+    list.forEach(function(v) {
+      if (v && v.name) {
+        codeNameMap.set(v.name.replace(REMOVE_SUFFIX_REGEX, ''), v);
+      } else {
+        log.warn('Anonymous matchers are not supported', v);
+      }
+    });
+  }
+
+  /**
+   * Recurse down the code AST node that is associated with this doc for a name
+   * @param  {Object} node The JS AST node information for the code to find the name of
+   * @return {String}      The name of the code or null if none found.
+   */
+  function findCodeName(node) {
+    var res = null;
+    if (node) {
+      var matcher = codeNameMap.get(node.type);
+      if (matcher) {
+        res = matcher(node);
+      } else {
+        log.warn('HELP! Unrecognised node type: %s', node.type);
+        log.warn(node);
+      }
+    }
+    return res;
+  }
+
+  var api = {
+    find: findCodeName
+  }
+
+  /**
+   * @property {Function[]} matchers AST node matchers
+   * @propertyof codeNameService
+   */
+  Object.defineProperty(api, 'matchers', {
+    set: registerCodeNameMatcher
+  });
+
+  return api;
+};

--- a/jsdoc/services/code-name.spec.js
+++ b/jsdoc/services/code-name.spec.js
@@ -1,0 +1,57 @@
+var Dgeni = require('dgeni');
+var mockPackage = require('../mocks/mockPackage');
+
+describe('code-name doc service', function() {
+  
+  var codeNameService, codeNameMap, mockLog;
+  
+  beforeEach(function() {
+    var dgeni = new Dgeni([mockPackage()]);
+    var injector = dgeni.configureInjector();
+    codeNameService = injector.get('codeNameService');
+    codeNameMap = injector.get('codeNameMap');
+    mockLog = injector.get('log');
+  });
+  
+  it("should register matcher", function() {
+    var testMatcher = function test () {};
+
+    codeNameService.matchers = [testMatcher];
+
+    expect(codeNameMap.get('test')).toEqual(testMatcher);
+  });
+
+  it("should strip suffix from matcher name", function() {
+    var testMatcher = function TestNodeMatcher () {};
+
+    codeNameService.matchers = [testMatcher];
+    
+    expect(codeNameMap.get('Test')).toEqual(testMatcher);
+  });
+
+  it("should log anonymous matcher and refuse registration", function() {
+    var testMatcher = function () {};
+
+    codeNameService.matchers = [testMatcher];
+    
+    expect(codeNameMap.get('Test')).toBeUndefined();
+  });
+
+  it("should return null for missing node", function() {
+    expect(codeNameService.find()).toBeNull();
+    expect(codeNameService.find(null)).toBeNull();
+  });
+
+  it("should process matcher for node", function() {
+    var testMatcher = function TestNodeMatcher () { return 'test'}
+
+    codeNameService.matchers = [testMatcher];
+
+    expect(codeNameService.find({type: 'Test'})).toEqual('test');
+  });
+
+  it("should warn unknown nodes", function() {
+    expect(codeNameService.find({type: 'Other'})).toBeNull();
+    expect(mockLog.warn).toHaveBeenCalledWith('HELP! Unrecognised node type: %s', 'Other');
+  });
+});


### PR DESCRIPTION
Fixes #160 and allows end-users to define their own matchers.

Probably it worth to implement proper strategy and use single implementation for the duplicate matchers (e.g. ObjectExpression and ArrayExpression).