### PR TITLE
fix(restrict): Change default from 'A' to 'EA'.

### DIFF
--- a/jsdoc/tag-defs/index.spec.js
+++ b/jsdoc/tag-defs/index.spec.js
@@ -3,7 +3,7 @@ var tagDefFactories = require('./');
 describe("jsdoc tagdefs", function() {
   it("should contain an array of tagDef factory functions", function() {
     expect(tagDefFactories).toEqual(jasmine.any(Array));
-    expect(tagDefFactories.length).toEqual(27);
+    expect(tagDefFactories.length).toEqual(26);
     tagDefFactories.forEach(function(factory) {
       expect(factory).toEqual(jasmine.any(Function));
     });

--- a/ngdoc/tag-defs/restrict.js
+++ b/ngdoc/tag-defs/restrict.js
@@ -3,7 +3,7 @@ module.exports = function() {
     name: 'restrict',
     defaultFn: function(doc) {
       if ( doc.docType === 'directive' || doc.docType === 'input' ) {
-        return { element: false, attribute: true, cssClass: false, comment: false };
+        return { element: true, attribute: true, cssClass: false, comment: false };
       }
     },
     transforms: function(doc, tag, value) {

--- a/ngdoc/tag-defs/restrict.spec.js
+++ b/ngdoc/tag-defs/restrict.spec.js
@@ -15,9 +15,9 @@ describe("restrict tag-def", function() {
     expect(tagDef.transforms({}, {}, 'ACEM')).toEqual({ element: true, attribute: true, cssClass: true, comment: true });
   });
 
-  it("should default to restricting to an attribute if no tag is found and the doc is for a directive", function() {
-    expect(tagDef.defaultFn({ docType: 'directive' })).toEqual({ element: false, attribute: true, cssClass: false, comment: false });
-    expect(tagDef.defaultFn({ docType: 'input' })).toEqual({ element: false, attribute: true, cssClass: false, comment: false });
+  it("should default to restricting to an element and attribute if no tag is found and the doc is for a directive", function() {
+    expect(tagDef.defaultFn({ docType: 'directive' })).toEqual({ element: true, attribute: true, cssClass: false, comment: false });
+    expect(tagDef.defaultFn({ docType: 'input' })).toEqual({ element: true, attribute: true, cssClass: false, comment: false });
   });
 
   it("should not add a restrict property if the docType is not 'directive'", function() {


### PR DESCRIPTION
According to https://docs.angularjs.org/api/ng/service/$compile, the default value for a directive's `restrict` property is `'EA'` instead of just `'A'`. Update code accordingly.

Also fix failing test due to 04b6e08e2ab109d76936ae49ae1cfd29a81b3874.