### PR TITLE
fix(jsdoc/access): refactor access tags and transforms to allow more configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,14 +129,26 @@ file.
 
 The `jsdoc` package contains definitions for a number of standard jsdoc tags including: `name`,
 `memberof`, `param`, `property`, `returns`, `module`, `description`, `usage`,
-`animations`, `constructor`, `class`, `classdesc`, `global`, `namespace`, `method`, `type` and
-`kind`.
+`animations`, `constructor`, `class`, `classdesc`, `global`, `namespace`, `method`, `type`,
+`kind`, `access`, `public`, `private` and `protected`.
 
 ### Services (Tag Transformations)
 
 This package provides a number of **Transform** services that are used in **Tag Definitions** to transform
 the value of the tag from the string in the tag description to something more meaningful in the doc.
 
+* `extractAccessTransform` - extract an access level (e.g. public, protected, private) from tags
+  You can configure this transform to register access tags and set the property where access info is written.
+  * `extractAccessTransform.allowedTags.set('tagName', [propertValue])` - register a tag that can act as
+    as an alias to set an access level. The propertyValue is optional and if not undefined will return this
+    value from the transform that will be written to the property. (defaults to `public:undefined`,
+    `private:undefined`, `protected:undefined`)
+  * `extractAccessTransformImpl.allowedDocTypes.set('docType')` - register a docType that can contain access
+    type tags (defaults to "property" and "method")
+  * `extractAccessTransformImpl.accessProperty` - specify the property to which to write the access value
+    (defaults to "access")
+  * `extractAccessTransformImpl.accessTagName` - specify the name of the tag that can hold access values
+    (defaults to "access")
 * `extractNameTransform` - extract a name from a tag
 * `extractTypeTransform` - extract a type from a tag
 * `trimWhitespaceTransform` - trim whitespace from before and after the tag value
@@ -356,27 +368,27 @@ of the example
 
 ### File Readers:
 
-* at the moment we are not using a filereader but the `readTypeScriptModules` processor to read our modules. 
+* at the moment we are not using a filereader but the `readTypeScriptModules` processor to read our modules.
 
 ### Processors
 
-* `readTypeScriptModules` - parse the `sourceFiles` with the help of the `tsParser` service and return a doc 
+* `readTypeScriptModules` - parse the `sourceFiles` with the help of the `tsParser` service and return a doc
 for each exported member. You can either pass an array of strings or an array of objects with `include` and
 `exclude` globbing patterns. A mix of both is possible as well.
 The processor can be configured to export private
 members (marked as `/** @internal */` as well as members starting with an underscore (`_`)) by setting the property
 `hidePrivateMembers` to `false`.
 Set `sortClassMembers` to `true` to sort instance and static members by name (defaults to order of appearence).
-You can ignore special exports by adding strings or regexes to the `ignoreExportsMatching` property (defaults to 
+You can ignore special exports by adding strings or regexes to the `ignoreExportsMatching` property (defaults to
 `___esModule`.
 
 ### Services
 
-* `convertPrivateClassesToInterfaces` - pass this service a list of exported docs and if it represents a 
+* `convertPrivateClassesToInterfaces` - pass this service a list of exported docs and if it represents a
 class that is marked as `/** @internal */` the doc will be converted to represent an interface.
 * `tsParser` - uses the typescript compiler and a host created by `createCompilerHost` to actually read
 and compile the source files. The docs are created from the symbols read by the typescript program.
-* `createCompilerHost` - creates a new compiler host which can, among other things, resolve file paths and 
+* `createCompilerHost` - creates a new compiler host which can, among other things, resolve file paths and
 check if files exist
 * `getContent` - retrieves the file contents and comments.
 

--- a/jsdoc/services/transforms/extract-access.js
+++ b/jsdoc/services/transforms/extract-access.js
@@ -1,11 +1,14 @@
 /**
- * Processes @access tag and its' aliases
- * As result fills up doc.access with correct access value
- *
- * @param  {Tag} tag The tag to process
+ * Extract the access property from the tag
  */
-module.exports = function accessTagTransform(createDocMessage, log) {
-  var tags = [], values = [];
+module.exports = function extractAccessTransform(createDocMessage) {
+
+  extractAccessTransformImpl.accessProperty = 'access';
+  extractAccessTransformImpl.accessTagName = 'access';
+  extractAccessTransformImpl.allowedDocTypes = new Set(['property', 'method']);
+  extractAccessTransformImpl.allowedTags = new Map();
+
+  return extractAccessTransformImpl;
 
   /**
    * Processes doc and returns correct access value
@@ -13,58 +16,64 @@ module.exports = function accessTagTransform(createDocMessage, log) {
    * @param {Tag} tag tag to process
    * @param {String} tag value
    */
-  function transformAccess (doc, tag, value) {
-    if ( !(doc.docType === 'property' || doc.docType === 'method') ) {
-      throw new Error(createDocMessage('"@'+ tag.tagDef.name +'" tag found on @'+ doc.docType +' document while defined for @property and @method only', doc));
+  function extractAccessTransformImpl (doc, tag, value) {
+
+    var static = extractAccessTransformImpl;
+
+    // Check if this docType is allowed to provide an access value
+    if ( !static.allowedDocTypes.has(doc.docType) ) {
+      throw new Error(createDocMessage('Illegal use of "@'+ tag.tagDef.name +'" tag.\n' +
+                                       'You can only use this tag on the following docTypes: ' + joinKeys(static.allowedDocTypes, ', ', '[ ', ' ]') + '.\n' +
+                                       'Register this docType with extractAccessTransform.addDocType("' + doc.docType + '") prior to use',
+                                       doc));
     }
 
-    if (tag.tagDef.name != 'access' && tag.tagDef.docProperty != 'access') {
-        throw new Error(createDocMessage('Tag @' + tag.tagDef.name + ' does not fill up doc.access property', doc));
+    // Check that we have not already provided this value
+    if ( doc[static.accessProperty] ) {
+      throw new Error(createDocMessage('Illegal use of "@' + tag.tagDef.name +'" tag.\n' +
+                                       '`doc.' + static.accessProperty + '` property is already defined as "' + doc[static.accessProperty] + '".\n' +
+                                       'Only one of the following tags allowed per doc: ' + joinKeys(static.allowedTags, '", "@', '[ "@access", "@', '" ]'), doc));
     }
 
-    if ( doc.access ) {
-        throw new Error(createDocMessage('Access value "' + doc.access + '" is already defined. Only one of [ "@' + tags.join('", "@') + '" ] per comment allowed', doc));
+    var tagName = tag.tagDef.name;
+    if ( tagName !== static.accessTagName ) {
+
+      // Check that the tag has been registered
+      if ( !static.allowedTags.has(tagName) ) {
+        throw new Error(createDocMessage('Register tag @' + tagName + ' with extractAccessTransform.allowedTags.set("' + tagName + '") prior to use', doc));
+      }
+      value = tagName;
     }
 
-    if (tags.indexOf(tag.tagDef.name) < 0) {
-        throw new Error(createDocMessage('Register tag @' + tag.tagDef.name + ' with accessTagTransform.addTag("' + tag.tagDef.name + '") prior to use', doc));
+    // Check that this access value is allowed
+    if ( !static.allowedTags.has(value) ) {
+      throw new Error(createDocMessage('Illegal value for `doc.' + static.accessProperty + '` property of "' + value + '".\n' +
+                                       'This property can only contain the following values: ' + joinKeys(static.allowedTags, '", "', '[ "', '" ]'),
+                                       doc));
     }
 
-    if (!value) {
-        value = tag.tagDef.name;
+    // Write the access value to the doc
+    doc[static.accessProperty] = value;
+
+    // Return true as the value of the tag if this tag type is to be written to the doc
+    if (static.allowedTags.has(value)) {
+      return static.allowedTags.get(value);
     }
+  }
 
-    if (values.indexOf(value) < 0) {
-        throw new Error(createDocMessage('@'+ tag.tagDef.name +' sets value "' + value + '". Only one of [ "' + values.join('", "') + '" ] allowed', doc));
+  function joinKeys(set, joiner, pre, post) {
+    var result = pre || '';
+    var first = true;
+    set.forEach(function(val, key) {
+      if (!first) {
+        result += joiner;
+      }
+      first = false;
+      result += key;
+    });
+    if (post) {
+      result += post;
     }
-
-    return value;
-  };
-
-  /**
-   * Adds tag to the list of allowed @access aliases
-   * @param {String} v tag name
-   * @returns {accessTagTransform} this for chaining
-   */
-  transformAccess.addTag = function addTag (v) {
-    if (tags.indexOf(v) > -1) {
-      log.error('Tag "' + v + '" is already defined');
-    }
-    tags.push(v);
-    return this;
-  };
-
-  /**
-   * Adds value the list of allowed @access values
-   * @param {String} v tag value
-   * @returns {accessTagTransform} this for chaining
-   */
-  transformAccess.addValue = function addValue (v) {
-    if (values.indexOf(v) < 0) {
-      values.push(v);
-    }
-    return this;
-  };
-
-  return transformAccess;
+    return result;
+  }
 };

--- a/jsdoc/tag-defs/access.js
+++ b/jsdoc/tag-defs/access.js
@@ -1,13 +1,8 @@
-module.exports = function(accessTagTransform, trimWhitespaceTransform) {
-  var name = 'access'
-  accessTagTransform.addTag(name);
-  accessTagTransform.addValue('private');
-  accessTagTransform.addValue('protected');
-  accessTagTransform.addValue('public');
-
+module.exports = function(extractAccessTransform) {
+  extractAccessTransformImpl.accessProperty = 'access';
+  extractAccessTransformImpl.accessTagName = 'access';
   return {
-    name: name,
-    docProperty: 'access',
-    transforms: [trimWhitespaceTransform, accessTagTransform]
+    name: 'access',
+    transforms: extractAccessTransform
   };
 };

--- a/jsdoc/tag-defs/access.spec.js
+++ b/jsdoc/tag-defs/access.spec.js
@@ -1,35 +1,19 @@
 var tagDefFactory = require('./access');
 
 describe("access tagDef", function() {
-  var accessTagTransform;
-  var trimWhitespaceTransform = function() {};
+  var extractAccessTransform;
 
   beforeEach(function() {
-    accessTagTransform = function() {};
-    accessTagTransform.addTag = jasmine.createSpy('addTag');
-    accessTagTransform.addValue = jasmine.createSpy('addValue');
+    extractAccessTransform = function() {};
   });
 
-  it("should have correct name and property", function() {
-    var tagDef = tagDefFactory(accessTagTransform, trimWhitespaceTransform);
-
+  it("should have the correct name", function() {
+    var tagDef = tagDefFactory(extractAccessTransform);
     expect(tagDef.name).toEqual('access');
-    expect(tagDef.docProperty).toEqual('access');
   });
 
   it("should add the injected transforms to the transforms property", function() {
-    var tagDef = tagDefFactory(accessTagTransform, trimWhitespaceTransform);
-
-    expect(tagDef.transforms).toEqual([trimWhitespaceTransform, accessTagTransform]);
+    var tagDef = tagDefFactory(extractAccessTransform);
+    expect(tagDef.transforms).toEqual(extractAccessTransform);
   });
-
-  it("should record itself in accessTagTransform service", function() {
-    tagDefFactory(accessTagTransform);
-
-    expect(accessTagTransform.addTag.calls.count()).toEqual(1);
-    expect(accessTagTransform.addValue.calls.count()).toEqual(3);
-    expect(accessTagTransform.addTag).toHaveBeenCalledWith('access');
-    expect(accessTagTransform.addValue.calls.allArgs()).toEqual([ ['private'], ['protected'], ['public'] ]);
-  });
-
 });

--- a/jsdoc/tag-defs/private.js
+++ b/jsdoc/tag-defs/private.js
@@ -1,16 +1,7 @@
-module.exports = function(accessTagTransform) {
-  var name = 'private';
-
-  accessTagTransform.addTag(name);
-  accessTagTransform.addValue(name);
-
-  function getValue () {
-    return name;
-  }
-
+module.exports = function(extractTypeTransform, extractAccessTransform) {
+  extractAccessTransform.allowedTags.set('private');
   return {
-    name: name,
-    docProperty: 'access',
-    transforms: [getValue, accessTagTransform]
+    name: 'private',
+    transforms: [extractTypeTransform, extractAccessTransform]
   };
 };

--- a/jsdoc/tag-defs/private.spec.js
+++ b/jsdoc/tag-defs/private.spec.js
@@ -1,39 +1,25 @@
 var tagDefFactory = require('./private');
 
 describe("private tagDef", function() {
-  var accessTagTransform;
+  var extractAccessTransform, extractTypeTransform, tagDef;
 
   beforeEach(function() {
-    accessTagTransform = jasmine.createSpy('transform');
-    accessTagTransform.addTag = jasmine.createSpy('addTag');
-    accessTagTransform.addValue = jasmine.createSpy('addValue');
+    extractTypeTransform = function() {};
+    extractAccessTransform = function() {};
+    extractAccessTransform.allowedTags = new Map();
+    tagDef = tagDefFactory(extractTypeTransform, extractAccessTransform);
   });
 
   it("should have correct name and property", function() {
-    var tagDef = tagDefFactory(accessTagTransform);
-
     expect(tagDef.name).toEqual('private');
-    expect(tagDef.docProperty).toEqual('access');
   });
 
   it("should add the injected transforms to the transforms property", function() {
-    var tagDef = tagDefFactory(accessTagTransform);
-
-    expect(tagDef.transforms).toEqual([jasmine.any(Function), accessTagTransform]);
+    expect(tagDef.transforms).toEqual([extractTypeTransform, extractAccessTransform]);
   });
 
-  it("should record itself in accessTagTransform service", function() {
-    tagDefFactory(accessTagTransform);
-
-    expect(accessTagTransform.addTag.calls.count()).toEqual(1);
-    expect(accessTagTransform.addValue.calls.count()).toEqual(1);
-    expect(accessTagTransform.addTag).toHaveBeenCalledWith('private');
-    expect(accessTagTransform.addValue).toHaveBeenCalledWith('private');
-  });
-
-  it("should set value to 'private' and ignore anything came from document", function () {
-    tagDef = tagDefFactory(accessTagTransform);
-
-    expect(tagDef.transforms[0](null, {}, null)).toEqual('private');
+  it("should record itself in extractAccessTransform service", function() {
+    expect(extractAccessTransform.allowedTags.has('private')).toBe(true);
+    expect(extractAccessTransform.allowedTags.get('private')).toBeUndefined();
   });
 });

--- a/jsdoc/tag-defs/protected.js
+++ b/jsdoc/tag-defs/protected.js
@@ -1,16 +1,7 @@
-module.exports = function(accessTagTransform) {
-  var name = 'protected';
-
-  accessTagTransform.addTag(name);
-  accessTagTransform.addValue(name);
-
-  function getValue() {
-    return name;
-  }
-
+module.exports = function(extractTypeTransform, extractAccessTransform) {
+  extractAccessTransform.allowedTags.set('protected');
   return {
-    name: name,
-    docProperty: 'access',
-    transforms: [getValue, accessTagTransform]
+    name: 'protected',
+    transforms: [extractTypeTransform, extractAccessTransform]
   };
 };

--- a/jsdoc/tag-defs/protected.spec.js
+++ b/jsdoc/tag-defs/protected.spec.js
@@ -1,39 +1,25 @@
 var tagDefFactory = require('./protected');
 
 describe("protected tagDef", function() {
-  var accessTagTransform;
+  var extractAccessTransform, extractTypeTransform, tagDef;
 
   beforeEach(function() {
-    accessTagTransform = function() {};
-    accessTagTransform.addTag = jasmine.createSpy('addTag');
-    accessTagTransform.addValue = jasmine.createSpy('addValue');
+    extractTypeTransform = function() {};
+    extractAccessTransform = function() {};
+    extractAccessTransform.allowedTags = new Map();
+    tagDef = tagDefFactory(extractTypeTransform, extractAccessTransform);
   });
 
   it("should have correct name and property", function() {
-    var tagDef = tagDefFactory(accessTagTransform);
-
     expect(tagDef.name).toEqual('protected');
-    expect(tagDef.docProperty).toEqual('access');
   });
 
   it("should add the injected transforms to the transforms property", function() {
-    var tagDef = tagDefFactory(accessTagTransform);
-
-    expect(tagDef.transforms).toEqual([jasmine.any(Function), accessTagTransform]);
+    expect(tagDef.transforms).toEqual([extractTypeTransform, extractAccessTransform]);
   });
 
-  it("should record itself in accessTagTransform service", function() {
-    tagDefFactory(accessTagTransform);
-
-    expect(accessTagTransform.addTag.calls.count()).toEqual(1);
-    expect(accessTagTransform.addValue.calls.count()).toEqual(1);
-    expect(accessTagTransform.addTag).toHaveBeenCalledWith('protected');
-    expect(accessTagTransform.addValue).toHaveBeenCalledWith('protected');
-  });
-
-  it("should set value to 'protected' and ignore anything came from document", function () {
-    tagDef = tagDefFactory(accessTagTransform);
-
-    expect(tagDef.transforms[0](null, {}, null)).toEqual('protected');
+  it("should record itself in extractAccessTransform service", function() {
+    expect(extractAccessTransform.allowedTags.has('protected')).toBe(true);
+    expect(extractAccessTransform.allowedTags.get('protected')).toBeUndefined();
   });
 });

--- a/jsdoc/tag-defs/public.js
+++ b/jsdoc/tag-defs/public.js
@@ -1,16 +1,7 @@
-module.exports = function(accessTagTransform) {
-  var name = 'public';
-
-  accessTagTransform.addTag(name);
-  accessTagTransform.addValue(name);
-
-  function getValue() {
-    return name;
-  }
-
+module.exports = function(extractTypeTransform, extractAccessTransform) {
+  extractAccessTransform.allowedTags.set('public');
   return {
-    name: name,
-    docProperty: 'access',
-    transforms: [getValue, accessTagTransform]
+    name: 'public',
+    transforms: [extractTypeTransform, extractAccessTransform]
   };
 };

--- a/jsdoc/tag-defs/public.spec.js
+++ b/jsdoc/tag-defs/public.spec.js
@@ -1,40 +1,25 @@
 var tagDefFactory = require('./public');
 
 describe("public tagDef", function() {
-  var accessTagTransform;
+  var extractAccessTransform, extractTypeTransform, tagDef;
 
   beforeEach(function() {
-    accessTagTransform = function() {};
-    accessTagTransform.addTag = jasmine.createSpy('addTag');
-    accessTagTransform.addValue = jasmine.createSpy('addValue');
+    extractTypeTransform = function() {};
+    extractAccessTransform = function() {};
+    extractAccessTransform.allowedTags = new Map();
+    tagDef = tagDefFactory(extractTypeTransform, extractAccessTransform);
   });
 
   it("should have correct name and property", function() {
-    var tagDef = tagDefFactory(accessTagTransform);
-
     expect(tagDef.name).toEqual('public');
-    expect(tagDef.docProperty).toEqual('access');
   });
 
   it("should add the injected transforms to the transforms property", function() {
-    var tagDef = tagDefFactory(accessTagTransform);
-
-    expect(tagDef.transforms).toEqual([jasmine.any(Function), accessTagTransform]);
+    expect(tagDef.transforms).toEqual([extractTypeTransform, extractAccessTransform]);
   });
 
-  it("should record itself in accessTagTransform service", function() {
-    tagDefFactory(accessTagTransform);
-
-    expect(accessTagTransform.addTag.calls.count()).toEqual(1);
-    expect(accessTagTransform.addValue.calls.count()).toEqual(1);
-    expect(accessTagTransform.addTag).toHaveBeenCalledWith('public');
-    expect(accessTagTransform.addValue).toHaveBeenCalledWith('public');
+  it("should record itself in extractAccessTransform service", function() {
+    expect(extractAccessTransform.allowedTags.has('public')).toBe(true);
+    expect(extractAccessTransform.allowedTags.get('public')).toBeUndefined();
   });
-
-  it("should set value to 'public' and ignore anything came from document", function () {
-    tagDef = tagDefFactory(accessTagTransform);
-
-    expect(tagDef.transforms[0](null, {}, null)).toEqual('public');
-  });
-
 });


### PR DESCRIPTION
With this change you can control whether access properties write a value to the
doc in addition to writing to the access property.
The `@access` tag and `doc.access` property names are also configurable.
You can also configure what docTypes are allowed to contain access tags.

Closes #168
Closes #169
Closes #170
Closes #171

BREAKING CHANGE

The way that you configure `extractAccessTransform` has changed. If you were creating
your own access tags then you must use the new API.

Previously:

```
module.exports = function(accessTagTransform) {
  var name = 'private';

  accessTagTransform.addTag(name);
  accessTagTransform.addValue(name);

  function getValue () {
    return name;
  }

  return {
    name: name,
    docProperty: 'access',
    transforms: [getValue, accessTagTransform]
  };
};
```

Now:

```
module.exports = function(extractTypeTransform, extractAccessTransform) {
  extractAccessTransform.allowedTags.set('private');
  return {
    name: 'private',
    transforms: [extractTypeTransform, extractAccessTransform]
  };
};
```