### PR TITLE
typescript package: make getReturnType more robust.

### DIFF
--- a/typescript/mocks/readTypeScriptModules/getReturnType.ts
+++ b/typescript/mocks/readTypeScriptModules/getReturnType.ts
@@ -1,0 +1,11 @@
+export class Parent {
+  someProp = {
+    foo: 'bar',
+  };
+}
+
+export class Child extends Parent {
+  someProp = Object.assign(this.someProp, {
+    bar: 'baz'
+  });
+}

--- a/typescript/processors/readTypeScriptModules.js
+++ b/typescript/processors/readTypeScriptModules.js
@@ -383,10 +383,16 @@ module.exports = function readTypeScriptModules(tsParser, modules, getFileInfo, 
       // The symbol does not have a "type" but it is being initialized
       // so we can deduce the type of from the initializer (mostly).
       if (declaration.initializer.expression) {
-        return declaration.initializer.expression.text.trim();
-      } else {
-        return getType(sourceFile, declaration.initializer).trim();
+        var initializerExpressionText = declaration.initializer.expression.text;
+        var intrinsicNameFromTypeChecker = typeChecker.getTypeOfSymbolAtLocation(symbol, sourceFile).intrinsicName;
+        // we might not have an expression text.
+        if (initializerExpressionText) {
+          return initializerExpressionText.replace(/\s+/g, ' ').trim();
+        } else if (intrinsicNameFromTypeChecker) {
+          return intrinsicNameFromTypeChecker.trim();
+        }
       }
+      return getType(sourceFile, declaration.initializer).trim();
     }
   }
 

--- a/typescript/processors/readTypeScriptModules.spec.js
+++ b/typescript/processors/readTypeScriptModules.spec.js
@@ -180,6 +180,23 @@ describe('readTypeScriptModules', function() {
       expect(moduleDoc.name).toEqual('privateModule');
     });
   });
+  
+  describe('getReturnType', function () {
+    it('should not throw if "declaration.initializer.expression.text" is undefined', function () {
+      processor.sourceFiles = ['getReturnType.ts'];      
+      var docs = [];
+      expect(function () { processor.$process(docs); }).not.toThrow();
+    });
+
+    it('should try get the type from the typeChecker if possible', function () {
+      processor.sourceFiles = ['getReturnType.ts'];      
+      var docs = [];
+      processor.$process(docs);
+      
+      var overriddenSomePropDoc = _.last(docs);
+      expect(overriddenSomePropDoc.returnType).toEqual('any');
+    });
+  });
 });
 
 function getNames(collection) {


### PR DESCRIPTION
@petebacondarwin I have a typescript file, where I am reassigning some properties. This causes the current implementation to fail with:
```
TypeError: Cannot read property 'trim' of undefined
    at getReturnType (C:\...\node_modules\dgeni-packages\typescript\processors\readTypeScriptModules.js:386:55)
    at createMemberDoc (C:\...\node_modules\dgeni-packages\typescript\processors\readTypeScriptModules.js:288:30)
    at C:\...\node_modules\dgeni-packages\typescript\processors\readTypeScriptModules.js:90:31
    at Array.forEach (native)
    at C:\...\node_modules\dgeni-packages\typescript\processors\readTypeScriptModules.js:56:34
    at Array.forEach (native)
    at Object.$process (C:\...\node_modules\dgeni-packages\typescript\processors\readTypeScriptModules.js:47:21)
    at C:\...\node_modules\dgeni\lib\Dgeni.js:202:28
    at _fulfilled (C:\...\node_modules\q\q.js:834:54)
    at self.promiseDispatch.done (C:\...\node_modules\q\q.js:863:30)
    at Promise.promise.promiseDispatch (C:\...\node_modules\q\q.js:796:13)
    at C:\...\node_modules\q\q.js:857:14
    at runSingle (C:\...\node_modules\q\q.js:137:13)
    at flush (C:\...\node_modules\q\q.js:125:13)
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```

reason is that `declaration.initializer.expression` is set, but not `declaration.initializer.expression.text`.

With this PR we optionally use the `typeChecker` to get some information about the property and if this fails as well we fall back to the previous `else` branch.