### PR TITLE
feat(typescript): ignore exports marked as "@private" in jsDoc content

### DIFF
--- a/typescript/mocks/readTypeScriptModules/privateExports.ts
+++ b/typescript/mocks/readTypeScriptModules/privateExports.ts
@@ -1,0 +1,12 @@
+export var x = 10;
+
+/**
+ * @private
+ */
+export var y = 12;
+
+
+/**
+ * @internal
+ */
+export class z { }

--- a/typescript/processors/readTypeScriptModules.js
+++ b/typescript/processors/readTypeScriptModules.js
@@ -68,6 +68,10 @@ module.exports = function readTypeScriptModules(tsParser, modules, getFileInfo, 
           if (!resolvedExport.declarations) return;
 
           var exportDoc = createExportDoc(exportSymbol.name, resolvedExport, moduleDoc, basePath, parseInfo.typeChecker);
+
+          // Ignore exports marked as "@private" in jsDoc content
+          if (hidePrivateMembers && exportDoc.shouldHideExport) return;
+
           log.debug('>>>> EXPORT: ' + exportDoc.name + ' (' + exportDoc.docType + ') from ' + moduleDoc.id);
 
           // Add this export doc to its module doc
@@ -205,6 +209,7 @@ module.exports = function readTypeScriptModules(tsParser, modules, getFileInfo, 
       aliasNames.push(moduleDoc.id + '/' + name + typeParamString);
     }
 
+    var content = getContent(declaration);
     var exportDoc = {
       docType: getExportDocType(exportSymbol),
       accessibility: getExportAccessibility(declaration),
@@ -216,10 +221,11 @@ module.exports = function readTypeScriptModules(tsParser, modules, getFileInfo, 
       decorators: getDecorators(declaration),
       aliases: aliasNames,
       moduleDoc: moduleDoc,
-      content: getContent(declaration),
+      content: content,
       fileInfo: getFileInfo(exportSymbol, basePath),
       location: getLocation(declaration),
-      additionalDeclarations: additionalDeclarations
+      additionalDeclarations: additionalDeclarations,
+      shouldHideExport: checkHideContent(content)
     };
 
     if (exportDoc.docType === 'var' || exportDoc.docType === 'const' || exportDoc.docType === 'let') {
@@ -441,6 +447,13 @@ module.exports = function readTypeScriptModules(tsParser, modules, getFileInfo, 
       end: ts.getLineAndCharacterOfPosition(sourceFile, declaration.end)
     };
     return location;
+  }
+
+  function checkHideContent(content) {
+    var jsDocContainsPrivate = (content || '').split('\n').some(function(row) {
+      return row.search(/@private|@access private|@internal/) >= 0;
+    });
+    return jsDocContainsPrivate;
   }
 
 };

--- a/typescript/processors/readTypeScriptModules.spec.js
+++ b/typescript/processors/readTypeScriptModules.spec.js
@@ -32,6 +32,30 @@ describe('readTypeScriptModules', function() {
       expect(exportedDoc.name).toEqual('AbstractClass');
     });
 
+    it('should exclude private exports', function() {
+      processor.sourceFiles = [ 'privateExports.ts' ];
+      var docs = [];
+      processor.$process(docs);
+
+      expect(docs.length).toBe(2);
+      expect(docs[1].name).toEqual('x');
+    });
+
+    it('should include private exports if flag hidePrivateMembers is false', function() {
+      processor.sourceFiles = [ 'privateExports.ts' ];
+      processor.hidePrivateMembers = false;
+      var docs = [];
+      processor.$process(docs);
+
+      expect(docs.length).toBe(4);
+      expect(docs[1].name).toEqual('x');
+      expect(docs[1].shouldHideExport).toBe(false);
+      expect(docs[2].name).toEqual('y');
+      expect(docs[2].shouldHideExport).toBe(true);
+      expect(docs[3].name).toEqual('z');
+      expect(docs[3].shouldHideExport).toBe(true);
+    });
+
     it('should hide members marked as private in TypeScript', function() {
       processor.sourceFiles = [ 'privateMembers.ts' ];
       var docs = [];


### PR DESCRIPTION
Ref. #199

It will be useful because in ionic2 they are using this functionality in their custom typescript processor: [repo link](https://github.com/driftyco/ionic/blob/master/scripts/docs/typescript-package/processors/readTypeScriptModules.js#L74-L78)

Adding also some tests for this functionality