### PR TITLE
fix(typescript): correctly extract the type definition from type aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 0.16.8 20 February 2017
+
+* fix(typescript): correctly extract the type definition from type aliases	573111ea
+
+
 # 0.16.7 15 February 2017
 
 Upgrades to dgeni 0.4.7 which correctly exports the mock logger for testing.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgeni-packages",
-  "version": "0.16.7",
+  "version": "0.16.8",
   "description": "A collection of dgeni packages for generating documentation from source code",
   "scripts": {
     "test": "jasmine-node .",

--- a/typescript/mocks/readTypeScriptModules/type-aliases.ts
+++ b/typescript/mocks/readTypeScriptModules/type-aliases.ts
@@ -1,0 +1,6 @@
+export class X<T> {
+
+}
+
+export const X2 = X;
+export type X2 = X<any>;

--- a/typescript/processors/readTypeScriptModules.js
+++ b/typescript/processors/readTypeScriptModules.js
@@ -176,7 +176,14 @@ module.exports = function readTypeScriptModules(tsParser, modules, getFileInfo, 
     }
 
     if (declaration.symbol.flags & ts.SymbolFlags.TypeAlias) {
-      typeDefinition = getText(sourceFile, declaration.type);
+      var type = declaration.type;
+      if (!type) {
+        // this symbol is a type alias but also a value declaration
+        // so we will search the additionalDeclarations for the type that is
+        // being aliased.
+        additionalDeclarations.some(function(decl) { return type = decl.type; });
+      }
+      typeDefinition = getText(sourceFile, type).trim();
     }
 
     if (declaration.heritageClauses) {

--- a/typescript/processors/readTypeScriptModules.spec.js
+++ b/typescript/processors/readTypeScriptModules.spec.js
@@ -122,6 +122,17 @@ describe('readTypeScriptModules', function() {
     });
   });
 
+  describe('type aliases', function() {
+    it('should find the correct type when there are multiple declarations', function() {
+      processor.sourceFiles = [ 'type-aliases.ts'];
+      var docs = [];
+      processor.$process(docs);
+      var typeAliasDoc = docs[2];
+      expect(typeAliasDoc.docType).toEqual('type-alias');
+      expect(typeAliasDoc.typeDefinition).toEqual('X<any>');
+    });
+  });
+
 
   describe('ordering of members', function() {
     it('should order class members in order of appearance (by default)', function() {


### PR DESCRIPTION
When aliasing a class one must create two declarations for a symbol:

```
class OriginalClass {}
const AliasedClass = OriginalClass;
type AliasedClass = OriginalClass;
```

Previously we were looking for the type on the value definition (i.e.
the `const`), and not finding it. Now if the type is not found on the
value definition then we search the other declarations for the first
to have a `type` property.

Related to https://github.com/angular/angular/pull/14523