### PR TITLE
fix(jsdoc): do not parse for tags within HTML blocks

### DIFF
--- a/jsdoc/index.js
+++ b/jsdoc/index.js
@@ -28,6 +28,8 @@ module.exports = new Package('jsdoc', [require('../base')])
 .factory(require('./services/transforms/unknown-tag'))
 .factory(require('./services/transforms/whole-tag'))
 .factory(require('./services/transforms/trim-whitespace'))
+.factory(require('./services/parser-adapters/backtick-parser-adapter'))
+.factory(require('./services/parser-adapters/html-block-parser-adapter'))
 
 .factory(require('./services/jsParser'))
 .factory(require('./file-readers/jsdoc'))

--- a/jsdoc/services/parser-adapters/backtick-parser-adapter.js
+++ b/jsdoc/services/parser-adapters/backtick-parser-adapter.js
@@ -1,0 +1,17 @@
+/**
+ * A ParserAdapter adapter that ignores tags between triple backtick blocks
+ */
+module.exports = function backTickParserAdapter() {
+  return {
+    init: function() {},
+    nextLine: function(line, lineNumber) {
+      const CODE_FENCE = /^\s*```(?!.*```)/;
+      if ( CODE_FENCE.test(line) ) {
+        this.inCode = !this.inCode;
+      }
+    },
+    parseForTags: function() {
+      return !this.inCode;
+    }
+  };
+};

--- a/jsdoc/services/parser-adapters/backtick-parser-adapter.spec.js
+++ b/jsdoc/services/parser-adapters/backtick-parser-adapter.spec.js
@@ -1,0 +1,79 @@
+const backTickParserAdapterFactory = require('./backtick-parser-adapter');
+const TagCollection = require('../../lib/TagCollection');
+
+describe('backTickParserAdapter', function() {
+  it("should ignore @tags inside back-ticked code blocks", function() {
+    const adapter = backTickParserAdapterFactory();
+    const lines = [
+      '@a some text',
+      '',
+      '',
+      '```',
+      '  some code',
+      '  @b not a tag',
+      '```',
+      '',
+      'more text',
+      '@b is a tag'
+    ];
+    adapter.init && adapter.init(lines, new TagCollection());
+
+    adapter.nextLine(lines[0], 0);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[1], 1);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[2], 2);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[3], 3);
+    expect(adapter.parseForTags()).toBeFalsy();
+    adapter.nextLine(lines[4], 4);
+    expect(adapter.parseForTags()).toBeFalsy();
+    adapter.nextLine(lines[5], 5);
+    expect(adapter.parseForTags()).toBeFalsy();
+    adapter.nextLine(lines[6], 6);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[7], 7);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[8], 8);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[9], 9);
+    expect(adapter.parseForTags()).toBeTruthy();
+  });
+
+
+  it("should cope with single line back-ticked code blocks", function() {
+    const adapter = backTickParserAdapterFactory();
+    const lines = [
+      '@a some text',
+      '',
+      '```some single line of code @b not a tag```',
+      '',
+      'some text outside a code block',
+      '```',
+      '  some code',
+      '  @b not a tag',
+      '```'
+    ];
+
+    adapter.init(lines, new TagCollection());
+
+    adapter.nextLine(lines[0], 0);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[1], 1);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[2], 2);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[3], 3);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[4], 4);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[5], 5);
+    expect(adapter.parseForTags()).toBeFalsy();
+    adapter.nextLine(lines[6], 6);
+    expect(adapter.parseForTags()).toBeFalsy();
+    adapter.nextLine(lines[7], 7);
+    expect(adapter.parseForTags()).toBeFalsy();
+    adapter.nextLine(lines[8], 8);
+    expect(adapter.parseForTags()).toBeTruthy();
+  });
+});

--- a/jsdoc/services/parser-adapters/html-block-parser-adapter.js
+++ b/jsdoc/services/parser-adapters/html-block-parser-adapter.js
@@ -1,0 +1,42 @@
+const TAG_REGEXP = /^<([a-zA-Z]+)\b[\s\S]*?>/;
+/**
+ * A ParserAdapter adapter that ignores tags between HTML blocks that would be ignored by markdown
+ * See https://daringfireball.net/projects/markdown/syntax#html
+ */
+module.exports = function htmlBlockParserAdapter() {
+  return {
+    init: function(lines) {
+      this.lines = lines;
+      this.tagDepth = 0;
+      this.currentTag = null;
+    },
+    nextLine: function(line, lineNumber) {
+      if (this.tagDepth === 0 && this.lines[lineNumber - 1] === '') {
+        const m = TAG_REGEXP.exec(line);
+        if (m) {
+          this.currentTag = m[1];
+        }
+      }
+      if (this.currentTag) {
+        this.tagDepth = this.tagDepth + countTags(line, '<' + this.currentTag) - countTags(line, '</' + this.currentTag);
+      }
+      if (this.tagDepth === 0) {
+        this.currentTag = null;
+      }
+    },
+    parseForTags: function() {
+      return !this.currentTag;
+    }
+  };
+};
+
+
+function countTags(line, marker) {
+  const regexp = new RegExp(marker + '\\b[\\s\\S]*?(/)?>', 'g');
+  let count = 0;
+  let match;
+  while(match = regexp.exec(line)) {
+    count += 1;
+  }
+  return count;
+}

--- a/jsdoc/services/parser-adapters/html-block-parser-adapter.spec.js
+++ b/jsdoc/services/parser-adapters/html-block-parser-adapter.spec.js
@@ -1,0 +1,71 @@
+const htmlBlockParserAdapterFactory = require('./html-block-parser-adapter');
+const TagCollection = require('../../lib/TagCollection');
+
+describe('htmlBlockParserAdapter', function() {
+  it("should ignore @tags inside inline HTML blocks", function() {
+    const adapter = htmlBlockParserAdapterFactory();
+    const lines = [
+      '@a some text',
+      '',
+      '<div class="x">',
+      '<div>some content</div>',
+      '<div>',
+      '    @b not a tag',
+      '</div>',
+      '@c still not a tag',
+      '',
+      '</div> // closing tag',
+      '',
+      '@b is a tag'
+    ];
+    adapter.init && adapter.init(lines, new TagCollection());
+
+    adapter.nextLine(lines[0], 0);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[1], 1);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[2], 2);
+    expect(adapter.parseForTags()).toBeFalsy();
+    adapter.nextLine(lines[3], 3);
+    expect(adapter.parseForTags()).toBeFalsy();
+    adapter.nextLine(lines[4], 4);
+    expect(adapter.parseForTags()).toBeFalsy();
+    adapter.nextLine(lines[5], 5);
+    expect(adapter.parseForTags()).toBeFalsy();
+    adapter.nextLine(lines[6], 6);
+    expect(adapter.parseForTags()).toBeFalsy();
+    adapter.nextLine(lines[7], 7);
+    expect(adapter.parseForTags()).toBeFalsy();
+    adapter.nextLine(lines[8], 8);
+    expect(adapter.parseForTags()).toBeFalsy();
+    adapter.nextLine(lines[9], 9);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[10], 10);
+    expect(adapter.parseForTags()).toBeTruthy();
+  });
+
+
+  it("should cope with single line HTML blocks", function() {
+    const adapter = htmlBlockParserAdapterFactory();
+    const lines = [
+      '@a some text',
+      '',
+      '<div>some single line of code @b not a tag</div>',
+      '',
+      'some text outside the HTML block',
+    ];
+
+    adapter.init(lines, new TagCollection());
+
+    adapter.nextLine(lines[0], 0);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[1], 1);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[2], 2);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[3], 3);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[4], 4);
+    expect(adapter.parseForTags()).toBeTruthy();
+  });
+});


### PR DESCRIPTION
In markdown you can provide inline HTML blocks which
are not parsed for further markdown syntax.

In the same way that the parseTagsProcessor ignored potential
tags inside backtick code blocks, it now also ignores potential
tags inside inline HTML blocks. These blocks are identified with
the same semantic as inline HTML in markdown.

This fix is implemented by making the parser more generic and the
modifying its behaviour by specifying "parser adapters".

Currently parse adapters must expose the following interface:

```
interface ParseAdapter {
  init(lines, tags);
  nextLine(line, lineNumber)
  parseForTags()
}
```

BREAKING CHANGE:

Tags inside HTML blocks are no longer parsed by default.
If you wish this to enable this then you can modify the
`parseTagsProcessor.parserAdapters` array from a config block:

```
somePackage.config(function(parseTagsProcessor, backtickParserAdapter) {
  parseTagsProcessor.parserAdapters = [backtickParserAdapter];
});
```