### PR TITLE
webRoot is added twich to the path

### DIFF
--- a/base/processors/checkAnchorLinks.js
+++ b/base/processors/checkAnchorLinks.js
@@ -84,7 +84,7 @@ module.exports = function checkAnchorLinksProcessor(log, resolveUrl, extractLink
           })
 
           .forEach(function(link) {
-            var normalizedLink = path.join(webRoot, resolveUrl(linkInfo.path, link, base));
+            var normalizedLink = resolveUrl(linkInfo.path, link, base);
             if ( !_.some(pathVariants, function(pathVariant) {
               return allValidReferences[decodeURIComponent(normalizedLink + pathVariant)];
             }) ) {


### PR DESCRIPTION
webRoot is added twice to the `linkInfo.path`. First on #L44 and for a second time on line #L87.
This means with a webRoot set, the reference will never resolve.

In checkAnchorLinks.spec.js it is not tested what happens when a webRoot is set.