### PR TITLE
fix(typescript): ensure that function types are not clobbered

### DIFF
--- a/typescript/mocks/readTypeScriptModules/spreadParams.ts
+++ b/typescript/mocks/readTypeScriptModules/spreadParams.ts
@@ -2,4 +2,5 @@ export function test(...args: Array<any>): void {}
 
 export interface Test {
   foo(...args: Array<any>): void;
+  foo2: (...args: Array<any>) => void;
 }

--- a/typescript/processors/readTypeScriptModules.js
+++ b/typescript/processors/readTypeScriptModules.js
@@ -442,9 +442,16 @@ module.exports = function readTypeScriptModules(tsParser, modules, getFileInfo, 
   }
 
 
-  // Strip any local renamed imports from the front of types
   function getType(sourceFile, type) {
     var text = getText(sourceFile, type);
+
+    if (type.kind === ts.SyntaxKind.FunctionType) {
+      // the type is a function, so we don't do any further processing
+      return text;
+    }
+
+    // Strip any local renamed imports from the front of types
+    // This approach is a bit naive and doesn't account for more complex types
     while (text.indexOf(".") >= 0) {
       // Keep some namespaced symbols
       if (_.some(ignoreTypeScriptNamespaces, function(regex) { return text.match(regex); })) break;

--- a/typescript/processors/readTypeScriptModules.spec.js
+++ b/typescript/processors/readTypeScriptModules.spec.js
@@ -231,9 +231,13 @@ describe('readTypeScriptModules', function() {
       expect(functionDoc.returnType).toEqual('void');
 
       const interfaceDoc = _.find(docs, { docType: 'interface' });
-      expect(interfaceDoc.members.length).toEqual(1);
-      expect(interfaceDoc.members[0].parameters).toEqual(['...args: Array<any>']);
-      expect(interfaceDoc.members[0].returnType).toEqual('void');
+      expect(interfaceDoc.members.length).toEqual(2);
+      const methodDoc = interfaceDoc.members[0];
+      expect(methodDoc.parameters).toEqual(['...args: Array<any>']);
+      expect(methodDoc.returnType).toEqual('void');
+
+      const propertyDoc = interfaceDoc.members[1];
+      expect(propertyDoc.returnType).toEqual('(...args: Array<any>) => void');
     });
   });
 


### PR DESCRIPTION
The heavy-handed approach of stripping locally renamed
imports via regular expressions was breaking types
that legitimately contained dots.

The most common of these types that was being
broken was anonymous function types that used the
spread operator.

This change special cases such function types and
does not process them for local renames.

Closes #222