### PR TITLE
feat(typescript): Allow decorators to not be call expressions. 

### DIFF
--- a/typescript/mocks/tsParser/getDecorators.test.ts
+++ b/typescript/mocks/tsParser/getDecorators.test.ts
@@ -1,0 +1,46 @@
+function classDecorator(target: any) {
+  // do nothing
+}
+function classDecoratorFactory(foo: string, bar: string) {
+  return classDecorator;
+}
+function propertyDecorator(target: any, propertyKey: string) {
+  // do nothing
+}
+function propertyDecoratorFactory(foo: string, bar: string) {
+  return propertyDecorator;
+}
+function methodDecorator(target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+  // do nothing
+}
+function methodDecoratorFactory(foo: string, bar: string) {
+  return methodDecorator;
+}
+function paramDecorator(target: any, propertyKey: string | symbol, parameterIndex: number) {
+  // do nothing
+}
+function paramDecoratorFactory(foo: string, bar: string) {
+  return paramDecorator;
+}
+
+/**
+ * A class "decorated" class
+ */
+@classDecorator
+@classDecoratorFactory('foo', 'bar')
+export class TestClass<T> {
+  /**
+   * Some property
+   */
+  @propertyDecorator
+  @propertyDecoratorFactory('foo', 'bar')
+  property: string;
+  /**
+   * Some method
+   */
+  @methodDecorator
+  @methodDecoratorFactory('foo', 'bar')
+  method(@paramDecorator param1: string, @paramDecoratorFactory('foo','bar') param2: number) {
+    // do nothing
+  }
+}

--- a/typescript/src/api-doc-types/ClassLikeExportDoc.ts
+++ b/typescript/src/api-doc-types/ClassLikeExportDoc.ts
@@ -3,7 +3,7 @@ import { ArrayLiteralExpression, CallExpression, Declaration, Decorator, Express
 
 import { FileInfo } from "../services/TsParser/FileInfo";
 import { getAccessibility } from "../services/TsParser/getAccessibility";
-import { getDecorators } from "../services/TsParser/getDecorators";
+import { getDecorators, ParsedDecorator } from "../services/TsParser/getDecorators";
 import { getTypeParametersText } from '../services/TsParser/getTypeParametersText';
 import { getTypeText } from '../services/TsParser/getTypeText';
 

--- a/typescript/src/api-doc-types/MemberDoc.ts
+++ b/typescript/src/api-doc-types/MemberDoc.ts
@@ -4,7 +4,7 @@ import { FileInfo } from '../services/TsParser/FileInfo';
 import { getAccessibility } from "../services/TsParser/getAccessibility";
 import { getContent } from "../services/TsParser/getContent";
 import { getDeclarationTypeText } from "../services/TsParser/getDeclarationTypeText";
-import { getDecorators } from "../services/TsParser/getDecorators";
+import { getDecorators, ParsedDecorator } from "../services/TsParser/getDecorators";
 import { getTypeText } from '../services/TsParser/getTypeText';
 import { ApiDoc } from './ApiDoc';
 import { ContainerExportDoc } from './ContainerExportDoc';

--- a/typescript/src/services/TsParser/getDecorators.spec.ts
+++ b/typescript/src/services/TsParser/getDecorators.spec.ts
@@ -1,0 +1,50 @@
+import { SignatureDeclaration } from 'typescript';
+import { TsParser } from '.';
+import { getDecorators, ParsedDecorator } from './getDecorators';
+const path = require('canonical-path');
+
+describe('getDecoratorSpec', () => {
+  let parser: TsParser;
+  let basePath: string;
+  beforeEach(() => {
+    parser = new TsParser(require('dgeni/lib/mocks/log')(false));
+    basePath = path.resolve(__dirname, '../../mocks');
+  });
+
+  it('should return the decorators of the declarations', () => {
+    const parseInfo = parser.parse(['tsParser/getDecorators.test.ts'], basePath);
+    const moduleExports = parseInfo.moduleSymbols[0].exportArray;
+    const testClass = moduleExports[0];
+
+    const testMethodDeclaration = testClass.members!.get('method')!.getDeclarations()[0];
+    const testParameters = (testMethodDeclaration as any).parameters;
+
+    const classDecorators = getDecorators(testClass.getDeclarations()[0])!;
+    const propertyDecorators = getDecorators(testClass.members!.get('property')!.getDeclarations()[0])!;
+    const methodDecorators = getDecorators(testMethodDeclaration)!;
+
+    testDecorator(classDecorators[0], 'classDecorator');
+    testDecorator(classDecorators[1], 'classDecoratorFactory', true);
+
+    testDecorator(propertyDecorators[0], 'propertyDecorator');
+    testDecorator(propertyDecorators[1], 'propertyDecoratorFactory', true);
+
+    testDecorator(methodDecorators[0], 'methodDecorator');
+    testDecorator(methodDecorators[1], 'methodDecoratorFactory', true);
+
+    testDecorator(getDecorators(testParameters[0])![0], 'paramDecorator');
+    testDecorator(getDecorators(testParameters[1])![0], 'paramDecoratorFactory', true);
+  });
+});
+
+function testDecorator(decorator: ParsedDecorator, name: string, isDecoratorFactory?: boolean) {
+  expect(decorator.expression).toBeDefined();
+  expect(decorator.name).toEqual(name);
+  if (isDecoratorFactory) {
+    expect(decorator.isCallExpression).toBeTruthy();
+    expect(decorator.argumentInfo).toEqual(["'foo'", "'bar'"]);
+    expect(decorator.arguments).toEqual(["'foo'", "'bar'"]);
+  } else {
+    expect(decorator.isCallExpression).toBeFalsy();
+  }
+}

--- a/typescript/src/services/TsParser/getDecorators.ts
+++ b/typescript/src/services/TsParser/getDecorators.ts
@@ -2,19 +2,33 @@ import { ArrayLiteralExpression, CallExpression, Declaration, Decorator, Express
 
 export type ArgumentInfo = string | string[] | { [key: string]: ArgumentInfo };
 
+export interface ParsedDecorator {
+  argumentInfo?: ArgumentInfo[];
+  arguments?: string[];
+  expression: Decorator;
+  isCallExpression: boolean;
+  name: string;
+}
+
 export function getDecorators(declaration: Declaration) {
   if (declaration.decorators) {
-    return declaration.decorators.map(decorator => {
+    return declaration.decorators.map<ParsedDecorator>(decorator => {
       const callExpression = getCallExpression(decorator);
-      if (!callExpression) {
-        throw new Error(`Expected decorator to be a call expression: ${decorator.getText()}`);
+      if (callExpression) {
+        return {
+          argumentInfo: callExpression.arguments.map(argument => parseArgument(argument)),
+          arguments: callExpression.arguments.map(argument => argument.getText()),
+          expression: decorator as Decorator,
+          isCallExpression: true,
+          name: callExpression.expression.getText(),
+        };
+      } else {
+        return {
+          expression: decorator as Decorator,
+          isCallExpression: false,
+          name: decorator.expression.getText(),
+        };
       }
-      return {
-        argumentInfo: callExpression.arguments.map(argument => parseArgument(argument)),
-        arguments: callExpression.arguments.map(argument => argument.getText()),
-        expression: decorator as Decorator,
-        name: callExpression.expression.getText(),
-      };
     });
   }
 }


### PR DESCRIPTION
Closes #229
For tests see: #233 