### PR TITLE
improve tracibility of error message

### DIFF
--- a/ngdoc/processors/memberDocs.js
+++ b/ngdoc/processors/memberDocs.js
@@ -34,7 +34,7 @@ module.exports = function memberDocsProcessor(log, getDocFromAlias, createDocMes
           var containerDocs = getDocFromAlias(doc.memberof, doc);
 
           if ( containerDocs.length === 0 ) {
-            log.warn(createDocMessage('Missing container document: "'+ doc.memberof + '"', doc));
+            log.warn(createDocMessage(doc.id +' - Missing container document: "'+ doc.memberof + '"', doc));
             return;
           }
 
@@ -42,7 +42,7 @@ module.exports = function memberDocsProcessor(log, getDocFromAlias, createDocMes
             // The memberof field was ambiguous, try prepending the module name too
             containerDocs = getDocFromAlias(_.template('${module}.${memberof}')(doc), doc);
             if ( containerDocs.length !== 1 ) {
-              log.warn(createDocMessage('Ambiguous container document reference: '+ doc.memberof));
+              log.warn(createDocMessage(doc.id +' - Ambiguous container document reference: '+ doc.memberof));
               return;
             }
           }

--- a/ngdoc/processors/memberDocs.js
+++ b/ngdoc/processors/memberDocs.js
@@ -34,7 +34,7 @@ module.exports = function memberDocsProcessor(log, getDocFromAlias, createDocMes
           var containerDocs = getDocFromAlias(doc.memberof, doc);
 
           if ( containerDocs.length === 0 ) {
-            log.warn(createDocMessage(doc.id +' - Missing container document: "'+ doc.memberof + '"', doc));
+            log.warn(createDocMessage('Missing container document: "'+ doc.memberof + '"', doc));
             return;
           }
 
@@ -42,7 +42,7 @@ module.exports = function memberDocsProcessor(log, getDocFromAlias, createDocMes
             // The memberof field was ambiguous, try prepending the module name too
             containerDocs = getDocFromAlias(_.template('${module}.${memberof}')(doc), doc);
             if ( containerDocs.length !== 1 ) {
-              log.warn(createDocMessage(doc.id +' - Ambiguous container document reference: '+ doc.memberof));
+              log.warn(createDocMessage('Ambiguous container document reference: '+ doc.memberof, doc));
               return;
             }
           }


### PR DESCRIPTION
The error message "Ambiguous container document reference" doesn't provide a source generating it. When I encountered it it just said "Ambiguous container document reference: labels" and labels is very common in my app so I had no idea where it was originating. My issue was solved by adding @module to all the doc blocks in my labels service (usually just adding to the overall one is sufficient).

Anyway, this would help track down where the error is coming from.