### PR TITLE
fix "npm run docs"

### DIFF
--- a/base/processors/read-files.js
+++ b/base/processors/read-files.js
@@ -133,7 +133,6 @@ function matchFileReader(fileReaders, file) {
 
 /**
  * Resolve the relative include/exclude paths in the sourceInfo object,
- * @private
  */
 function normalizeSourceInfo(basePath, sourceInfo) {
 

--- a/dgeni/processors/computeProcessorPipeline.js
+++ b/dgeni/processors/computeProcessorPipeline.js
@@ -1,4 +1,4 @@
-var sortByDependency = require('dgeni/lib/util/dependency-sort');
+var sortByDependency = require('dgeni/lib/util/dependency-sort').sortByDependency;
 
 module.exports = function computeProcessorPipeline() {
   return {

--- a/dgeni/processors/wireUpServicesToPackages.js
+++ b/dgeni/processors/wireUpServicesToPackages.js
@@ -16,7 +16,7 @@ module.exports = function wireUpServicesToPackages() {
       });
 
       docs.forEach(function(doc) {
-        if(doc.docType === 'dgService') {
+        if(doc.docType === 'dgService' || doc.docType === 'dgProcessor') {
           doc.name = doc.name || doc.codeName;
           doc.packageDoc = services[doc.name];
           doc.packageDoc.services.push(doc);


### PR DESCRIPTION
#206  Should I remove the '@private' tag  in `base/processors/read-files.js` ?

I'm not sure if there are other considerations leaving an '@private' tag there.

Now, before `npm run docs`, I had remove that tag manually.