### PR TITLE
feat(typescript): add `realFilePath`/`realProjectRelativePath` to `FileInfo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ Here is an example of some standard template patterns:
 ```js
 templateFinder.templatePatterns = [
   '${ doc.template }',
-  '${doc.area}/${ doc.id }.${ doc.docType }.template.html',
-  '${doc.area}/${ doc.id }.template.html',
-  '${doc.area}/${ doc.docType }.template.html',
+  '${ doc.area }/${ doc.id }.${ doc.docType }.template.html',
+  '${ doc.area }/${ doc.id }.template.html',
+  '${ doc.area }/${ doc.docType }.template.html',
   '${ doc.id }.${ doc.docType }.template.html',
   '${ doc.id }.template.html',
   '${ doc.docType }.template.html'
@@ -205,7 +205,7 @@ The `ngdoc` Package depends upon the `jsdoc` and `nunjucks` packages. It provide
 non-API documents written in files with `.ngdoc` extension; it also computes additional properties specific
 to Angular related code.
 
-## File Readers
+### File Readers
 
 * `ngdoc` - can pull a single document from an ngdoc content file.
 

--- a/typescript/src/services/TsParser/FileInfo.spec.ts
+++ b/typescript/src/services/TsParser/FileInfo.spec.ts
@@ -1,11 +1,14 @@
 import { TsParser } from '.';
 import { FileInfo } from './FileInfo';
+const fs = require('fs');
 const path = require('canonical-path');
 
 describe('FileInfo', () => {
   let parser: TsParser;
   let basePath: string;
   beforeEach(() => {
+    spyOn(fs, 'realpathSync').and.callFake((filePath: string) => filePath + '.real');
+
     parser = new TsParser(require('dgeni/lib/mocks/log')(false));
     basePath = path.resolve(__dirname, '../../mocks');
   });
@@ -15,30 +18,67 @@ describe('FileInfo', () => {
 
     const module = parseInfo.moduleSymbols[0];
     const fileInfo1 = new FileInfo(module.exportArray[0].declarations![0], basePath);
-    expect(fileInfo1.baseName).toEqual('testSrc');
-    expect(fileInfo1.basePath).toEqual(basePath);
-    expect(fileInfo1.extension).toEqual('ts');
-    expect(fileInfo1.filePath).toEqual(basePath + '/tsParser/testSrc.ts');
+    expect(fileInfo1.baseName).toBe('testSrc');
+    expect(fileInfo1.basePath).toBe(basePath);
+    expect(fileInfo1.extension).toBe('ts');
+    expect(fileInfo1.filePath).toBe(basePath + '/tsParser/testSrc.ts');
     expect(fileInfo1.location).toEqual(jasmine.objectContaining({ start: { line: 6, character: 30 }, end: { line: 28, character: 1 } }));
-    expect(fileInfo1.projectRelativePath).toEqual('tsParser/testSrc.ts');
-    expect(fileInfo1.relativePath).toEqual('tsParser/testSrc.ts');
+    expect(fileInfo1.projectRelativePath).toBe('tsParser/testSrc.ts');
+    expect(fileInfo1.realFilePath).toBe(fileInfo1.filePath + '.real');
+    expect(fileInfo1.realProjectRelativePath).toBe('tsParser/testSrc.ts.real');
+    expect(fileInfo1.relativePath).toBe('tsParser/testSrc.ts');
 
     const fileInfo2 = new FileInfo(module.exportArray[1].declarations![0], basePath);
-    expect(fileInfo2.baseName).toEqual('testSrc');
-    expect(fileInfo2.basePath).toEqual(basePath);
-    expect(fileInfo2.extension).toEqual('ts');
-    expect(fileInfo2.filePath).toEqual(basePath + '/tsParser/testSrc.ts');
+    expect(fileInfo2.baseName).toBe('testSrc');
+    expect(fileInfo2.basePath).toBe(basePath);
+    expect(fileInfo2.extension).toBe('ts');
+    expect(fileInfo2.filePath).toBe(basePath + '/tsParser/testSrc.ts');
     expect(fileInfo2.location).toEqual(jasmine.objectContaining({ start: { line: 33, character: 10 }, end: { line: 33, character: 42 } }));
-    expect(fileInfo2.projectRelativePath).toEqual('tsParser/testSrc.ts');
-    expect(fileInfo2.relativePath).toEqual('tsParser/testSrc.ts');
+    expect(fileInfo2.projectRelativePath).toBe('tsParser/testSrc.ts');
+    expect(fileInfo2.realFilePath).toBe(fileInfo2.filePath + '.real');
+    expect(fileInfo2.realProjectRelativePath).toBe('tsParser/testSrc.ts.real');
+    expect(fileInfo2.relativePath).toBe('tsParser/testSrc.ts');
 
     const fileInfo3 = new FileInfo(module.exportArray[2].declarations![0], basePath);
-    expect(fileInfo3.baseName).toEqual('importedSrc');
-    expect(fileInfo3.basePath).toEqual(basePath);
-    expect(fileInfo3.extension).toEqual('ts');
-    expect(fileInfo3.filePath).toEqual(basePath + '/tsParser/importedSrc.ts');
+    expect(fileInfo3.baseName).toBe('importedSrc');
+    expect(fileInfo3.basePath).toBe(basePath);
+    expect(fileInfo3.extension).toBe('ts');
+    expect(fileInfo3.filePath).toBe(basePath + '/tsParser/importedSrc.ts');
     expect(fileInfo3.location).toEqual(jasmine.objectContaining({ start: { line: 2, character: 12 }, end: { line: 2, character: 20 } }));
-    expect(fileInfo3.projectRelativePath).toEqual('tsParser/importedSrc.ts');
-    expect(fileInfo3.relativePath).toEqual('tsParser/importedSrc.ts');
+    expect(fileInfo3.projectRelativePath).toBe('tsParser/importedSrc.ts');
+    expect(fileInfo3.realFilePath).toBe(fileInfo3.filePath + '.real');
+    expect(fileInfo3.realProjectRelativePath).toBe('tsParser/importedSrc.ts.real');
+    expect(fileInfo3.relativePath).toBe('tsParser/importedSrc.ts');
+  });
+
+  describe('getRealFilePath()', () => {
+    const originalPathSep = path.sep;
+    afterEach(() => path.sep = originalPathSep);
+
+    it('should call `fs.realpathSync()`', () => {
+      const parseInfo = parser.parse(['tsParser/testSrc.ts'], basePath);
+      const module = parseInfo.moduleSymbols[0];
+      const fileInfo = new FileInfo(module.exportArray[0].declarations![0], basePath);
+
+      expect(fs.realpathSync).toHaveBeenCalledWith(fileInfo.filePath);
+    });
+
+    it('should normalize path separators to `/`', () => {
+      const parseInfo = parser.parse(['tsParser/testSrc.ts'], basePath);
+      const module = parseInfo.moduleSymbols[0];
+      let fileInfo;
+
+      path.sep = '\\';
+      fs.realpathSync.and.returnValue('C:\\Foo\\bar.ts');
+      fileInfo = new FileInfo(module.exportArray[0].declarations![0], basePath);
+
+      expect(fileInfo.realFilePath).toBe('C:/Foo/bar.ts');
+
+      path.sep = '/';
+      fs.realpathSync.and.returnValue('/Foo/bar.ts');
+      fileInfo = new FileInfo(module.exportArray[0].declarations![0], basePath);
+
+      expect(fileInfo.realFilePath).toBe('/Foo/bar.ts');
+    });
   });
 });

--- a/typescript/src/services/TsParser/FileInfo.ts
+++ b/typescript/src/services/TsParser/FileInfo.ts
@@ -1,5 +1,6 @@
 import { Declaration } from 'typescript';
 import { Location } from './Location';
+import { realpathSync } from 'fs';
 const path = require('canonical-path');
 
 /**
@@ -12,9 +13,15 @@ export class FileInfo {
   baseName = path.basename(this.filePath, path.extname(this.filePath));
   extension = path.extname(this.filePath).replace(/^\./, '');
   projectRelativePath = path.relative(this.basePath, this.filePath);
+  realFilePath = this.getRealFilePath(this.filePath);
+  realProjectRelativePath = path.relative(this.basePath, this.realFilePath);
 
   constructor(
     private declaration: Declaration,
     public basePath: string) {
+  }
+
+  getRealFilePath(filePath: string): string {
+    return realpathSync(filePath).replace(RegExp('\\' + path.sep, 'g'), '/');
   }
 }

--- a/typescript/src/services/convertPrivateClassesToInterfaces.spec.ts
+++ b/typescript/src/services/convertPrivateClassesToInterfaces.spec.ts
@@ -1,5 +1,6 @@
 import { DocCollection } from 'dgeni';
 import { ClassExportDoc } from '../api-doc-types/ClassExportDoc';
+import { FileInfo } from './TsParser/FileInfo';
 import { convertPrivateClassesToInterfaces } from './convertPrivateClassesToInterfaces';
 
 describe('convertPrivateClassesToInterfaces', () => {
@@ -16,6 +17,8 @@ describe('convertPrivateClassesToInterfaces', () => {
   let docs: DocCollection;
 
   beforeEach(() => {
+    spyOn(FileInfo.prototype, 'getRealFilePath').and.callFake((filePath: string) => filePath);
+
     classDoc = new ClassExportDoc(moduleDoc, classSymbol, basePath, true, []);
     classDoc.constructorDoc = { internal: true } as any;
     docs = [classDoc];


### PR DESCRIPTION
The file paths returned by TypeScript may contain symlinks. This is fine most of the time, since the path points to the correct file, but in certain cases (e.g. when we want to generate GitHub links based on the project-relative path) it is necessary to know the real path to the file (without symlinks).

This commit adds two new properties, `realFilePath` and `realProjectRelativePath`, which are based on the real path to the file.

(Related to angular/angular#18353.)