### PR TITLE
fix(base): support webRoot in checkAnchorLinks processor

### DIFF
--- a/base/processors/checkAnchorLinks.js
+++ b/base/processors/checkAnchorLinks.js
@@ -42,7 +42,7 @@ module.exports = function checkAnchorLinksProcessor(log, resolveUrl, extractLink
         if ( checkDoc(doc) ) {
 
           // Make the path to the doc relative to the webRoot
-          var docPath = path.join(webRoot, resolveUrl(base, doc.path, base));
+          var docPath = path.resolve(webRoot, resolveUrl(base, doc.path, base));
 
           // Parse out all link hrefs, names and ids
           linkInfo = extractLinks(doc.renderedContent);
@@ -85,7 +85,7 @@ module.exports = function checkAnchorLinksProcessor(log, resolveUrl, extractLink
           })
 
           .forEach(function(link) {
-            var normalizedLink = path.join(webRoot, resolveUrl(linkInfo.path, link, base));
+            var normalizedLink = path.resolve(webRoot, resolveUrl(linkInfo.path, link, base));
             if ( !_.some(pathVariants, function(pathVariant) {
               return allValidReferences[normalizedLink + pathVariant];
             }) ) {

--- a/base/processors/checkAnchorLinks.spec.js
+++ b/base/processors/checkAnchorLinks.spec.js
@@ -120,4 +120,32 @@ describe("checkAnchorLinks", function() {
     ]);
     expect(mockLog.warn).not.toHaveBeenCalled();
   });
+
+  it('should support webRoot configuration option', () => {
+    processor.webRoot = '/a/b/c';
+    processor.$process([
+      { renderedContent: '<a href="/a/b/c/foo"></a>', outputPath: 'doc/path.html', path: 'doc/path' },
+      { renderedContent: '<a href="foo"></a>', outputPath: '/a/b/c/path2.html', path: '/a/b/c/path2' },
+      { renderedContent: 'CONTENT OF FOO', outputPath: 'foo.html', path: 'foo' }
+    ]);
+    expect(mockLog.warn).not.toHaveBeenCalled();
+  });
+
+  it('should support base configuration option', () => {
+    processor.base = '/';
+    processor.$process([
+      { renderedContent: '<a href="foo"></a>', outputPath: 'doc/path.html', path: 'doc/path' },
+      { renderedContent: '<a href="foo"></a>', outputPath: '/a/b/c/path2.html', path: '/a/b/c/path2' },
+      { renderedContent: 'CONTENT OF FOO', outputPath: 'foo.html', path: 'foo' }
+    ]);
+    expect(mockLog.warn).not.toHaveBeenCalled();
+  });
+
+  it('should support relative url paths', () => {
+    processor.$process([
+      { renderedContent: '<a href="bar"></a>', outputPath: 'foo.html', path: 'foo' },
+      { renderedContent: 'CONTENT OF BAR', outputPath: 'bar.html', path: 'bar' }
+    ]);
+    expect(mockLog.warn).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
The webRoot was been prepended (via `path.join`) instead of being used
to resolve any leftover relative paths (via `path.resolve`).

Closes #217