### PR TITLE
Added support for named exports

### DIFF
--- a/jsdoc/services/code-name-matchers/export-default-declaration.js
+++ b/jsdoc/services/code-name-matchers/export-default-declaration.js
@@ -8,6 +8,6 @@ module.exports = function ExportDefaultDeclarationNodeMatcherFactory (codeNameSe
    * @returns {String|Null} code name from node
    */
   return function ExportDefaultDeclarationNodeMatcher (node) {
-    return null;
+    return codeNameService.find(node.right) || codeNameService.find(node.left) || null;
   }
 };

--- a/jsdoc/services/code-name-matchers/export-default-declaration.js
+++ b/jsdoc/services/code-name-matchers/export-default-declaration.js
@@ -8,6 +8,6 @@ module.exports = function ExportDefaultDeclarationNodeMatcherFactory (codeNameSe
    * @returns {String|Null} code name from node
    */
   return function ExportDefaultDeclarationNodeMatcher (node) {
-    return codeNameService.find(node.right) || codeNameService.find(node.left) || null;
+    return codeNameService.find(node.right) || null;
   }
 };

--- a/jsdoc/services/code-name-matchers/export-default-declaration.spec.js
+++ b/jsdoc/services/code-name-matchers/export-default-declaration.spec.js
@@ -1,14 +1,56 @@
 var matcherFactory = require('./export-default-declaration');
 
 describe('ExportDefaultDeclaration matcher', function() {
-
-  var matcher;
+  
+  var matcher, codeNameServiceMock;
 
   beforeEach(function() {
-    matcher = matcherFactory();
+    codeNameServiceMock = {
+      find: function (arg) {
+        return arg;
+      }
+    };
+    matcher = matcherFactory(codeNameServiceMock);
   });
 
-  it("should return null for any argument", function() {
-    expect(matcher({})).toBeNull();
+  it("should start search for right", function () {
+    var expr = {
+      left: 'left',
+      right: 'right'
+    };
+
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher(expr)).toEqual(expr.right);
+    expect(codeNameServiceMock.find.calls.count()).toEqual(1);
+    expect(codeNameServiceMock.find).toHaveBeenCalledWith(expr.right);
+  });
+
+  it("should continue search with left", function () {
+    codeNameServiceMock.value = null;
+    var expr = {
+      left: 'test',
+      right: null
+    };
+
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher(expr)).toEqual(expr.left);
+    expect(codeNameServiceMock.find.calls.count()).toEqual(2);
+    expect(codeNameServiceMock.find.calls.allArgs()).toEqual([[null],[expr.left]]);
+  });
+
+  it("should return null for empty left and right", function () {
+    codeNameServiceMock.value = null;
+    var expr = {
+      left: null,
+      right: null
+    };
+
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher(expr)).toBeNull();
+    expect(codeNameServiceMock.find.calls.count()).toEqual(2);
+    expect(codeNameServiceMock.find.calls.allArgs()).toEqual([[null],[null]]);
   });
 });

--- a/jsdoc/services/code-name-matchers/export-default-declaration.spec.js
+++ b/jsdoc/services/code-name-matchers/export-default-declaration.spec.js
@@ -1,7 +1,7 @@
 var matcherFactory = require('./export-default-declaration');
 
 describe('ExportDefaultDeclaration matcher', function() {
-  
+
   var matcher, codeNameServiceMock;
 
   beforeEach(function() {
@@ -15,7 +15,6 @@ describe('ExportDefaultDeclaration matcher', function() {
 
   it("should start search for right", function () {
     var expr = {
-      left: 'left',
       right: 'right'
     };
 
@@ -26,31 +25,16 @@ describe('ExportDefaultDeclaration matcher', function() {
     expect(codeNameServiceMock.find).toHaveBeenCalledWith(expr.right);
   });
 
-  it("should continue search with left", function () {
+  it("should return null for empty right", function () {
     codeNameServiceMock.value = null;
     var expr = {
-      left: 'test',
-      right: null
-    };
-
-    spyOn(codeNameServiceMock, 'find').and.callThrough();
-
-    expect(matcher(expr)).toEqual(expr.left);
-    expect(codeNameServiceMock.find.calls.count()).toEqual(2);
-    expect(codeNameServiceMock.find.calls.allArgs()).toEqual([[null],[expr.left]]);
-  });
-
-  it("should return null for empty left and right", function () {
-    codeNameServiceMock.value = null;
-    var expr = {
-      left: null,
       right: null
     };
 
     spyOn(codeNameServiceMock, 'find').and.callThrough();
 
     expect(matcher(expr)).toBeNull();
-    expect(codeNameServiceMock.find.calls.count()).toEqual(2);
-    expect(codeNameServiceMock.find.calls.allArgs()).toEqual([[null],[null]]);
+    expect(codeNameServiceMock.find.calls.count()).toEqual(1);
+    expect(codeNameServiceMock.find.calls.allArgs()).toEqual([[null]]);
   });
 });

--- a/jsdoc/services/code-name-matchers/export-named-declaration.js
+++ b/jsdoc/services/code-name-matchers/export-named-declaration.js
@@ -8,6 +8,6 @@ module.exports = function ExportNamedDeclarationNodeMatcherFactory (codeNameServ
    * @returns {String|Null} code name from node
    */
   return function ExportNamedDeclarationNodeMatcher (node) {
-    return codeNameService.find(node.right) || codeNameService.find(node.left) || null;
+    return codeNameService.find(node.right) || null;
   }
 };

--- a/jsdoc/services/code-name-matchers/export-named-declaration.js
+++ b/jsdoc/services/code-name-matchers/export-named-declaration.js
@@ -1,0 +1,13 @@
+/**
+ * @dgService ExportNamedDeclarationNodeMatcher
+ * @returns {String|Null} code name from node
+ */
+module.exports = function ExportNamedDeclarationNodeMatcherFactory (codeNameService) {
+  /**
+   * @param {Node} node AST node to process
+   * @returns {String|Null} code name from node
+   */
+  return function ExportNamedDeclarationNodeMatcher (node) {
+    return null;
+  }
+};

--- a/jsdoc/services/code-name-matchers/export-named-declaration.js
+++ b/jsdoc/services/code-name-matchers/export-named-declaration.js
@@ -8,6 +8,6 @@ module.exports = function ExportNamedDeclarationNodeMatcherFactory (codeNameServ
    * @returns {String|Null} code name from node
    */
   return function ExportNamedDeclarationNodeMatcher (node) {
-    return null;
+    return codeNameService.find(node.right) || codeNameService.find(node.left) || null;
   }
 };

--- a/jsdoc/services/code-name-matchers/export-named-declaration.spec.js
+++ b/jsdoc/services/code-name-matchers/export-named-declaration.spec.js
@@ -1,7 +1,7 @@
 var matcherFactory = require('./export-named-declaration');
 
 describe('ExportNamedDeclaration matcher', function() {
-
+  
   var matcher, codeNameServiceMock;
 
   beforeEach(function() {
@@ -15,7 +15,6 @@ describe('ExportNamedDeclaration matcher', function() {
 
   it("should start search for right", function () {
     var expr = {
-      left: 'left',
       right: 'right'
     };
 
@@ -26,31 +25,16 @@ describe('ExportNamedDeclaration matcher', function() {
     expect(codeNameServiceMock.find).toHaveBeenCalledWith(expr.right);
   });
 
-  it("should continue search with left", function () {
+  it("should return null for empty right", function () {
     codeNameServiceMock.value = null;
     var expr = {
-      left: 'test',
-      right: null
-    };
-
-    spyOn(codeNameServiceMock, 'find').and.callThrough();
-
-    expect(matcher(expr)).toEqual(expr.left);
-    expect(codeNameServiceMock.find.calls.count()).toEqual(2);
-    expect(codeNameServiceMock.find.calls.allArgs()).toEqual([[null],[expr.left]]);
-  });
-
-  it("should return null for empty left and right", function () {
-    codeNameServiceMock.value = null;
-    var expr = {
-      left: null,
       right: null
     };
 
     spyOn(codeNameServiceMock, 'find').and.callThrough();
 
     expect(matcher(expr)).toBeNull();
-    expect(codeNameServiceMock.find.calls.count()).toEqual(2);
-    expect(codeNameServiceMock.find.calls.allArgs()).toEqual([[null],[null]]);
+    expect(codeNameServiceMock.find.calls.count()).toEqual(1);
+    expect(codeNameServiceMock.find.calls.allArgs()).toEqual([[null]]);
   });
 });

--- a/jsdoc/services/code-name-matchers/export-named-declaration.spec.js
+++ b/jsdoc/services/code-name-matchers/export-named-declaration.spec.js
@@ -2,13 +2,55 @@ var matcherFactory = require('./export-named-declaration');
 
 describe('ExportNamedDeclaration matcher', function() {
 
-  var matcher;
+  var matcher, codeNameServiceMock;
 
   beforeEach(function() {
-    matcher = matcherFactory();
+    codeNameServiceMock = {
+      find: function (arg) {
+        return arg;
+      }
+    };
+    matcher = matcherFactory(codeNameServiceMock);
   });
 
-  it("should return null for any argument", function() {
-    expect(matcher({})).toBeNull();
+  it("should start search for right", function () {
+    var expr = {
+      left: 'left',
+      right: 'right'
+    };
+
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher(expr)).toEqual(expr.right);
+    expect(codeNameServiceMock.find.calls.count()).toEqual(1);
+    expect(codeNameServiceMock.find).toHaveBeenCalledWith(expr.right);
+  });
+
+  it("should continue search with left", function () {
+    codeNameServiceMock.value = null;
+    var expr = {
+      left: 'test',
+      right: null
+    };
+
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher(expr)).toEqual(expr.left);
+    expect(codeNameServiceMock.find.calls.count()).toEqual(2);
+    expect(codeNameServiceMock.find.calls.allArgs()).toEqual([[null],[expr.left]]);
+  });
+
+  it("should return null for empty left and right", function () {
+    codeNameServiceMock.value = null;
+    var expr = {
+      left: null,
+      right: null
+    };
+
+    spyOn(codeNameServiceMock, 'find').and.callThrough();
+
+    expect(matcher(expr)).toBeNull();
+    expect(codeNameServiceMock.find.calls.count()).toEqual(2);
+    expect(codeNameServiceMock.find.calls.allArgs()).toEqual([[null],[null]]);
   });
 });

--- a/jsdoc/services/code-name-matchers/export-named-declaration.spec.js
+++ b/jsdoc/services/code-name-matchers/export-named-declaration.spec.js
@@ -1,0 +1,14 @@
+var matcherFactory = require('./export-named-declaration');
+
+describe('ExportNamedDeclaration matcher', function() {
+
+  var matcher;
+
+  beforeEach(function() {
+    matcher = matcherFactory();
+  });
+
+  it("should return null for any argument", function() {
+    expect(matcher({})).toBeNull();
+  });
+});

--- a/jsdoc/services/code-name-matchers/index.js
+++ b/jsdoc/services/code-name-matchers/index.js
@@ -5,6 +5,7 @@ module.exports = [
   require('./call-expression.js'),
   require('./class-declaration.js'),
   require('./export-default-declaration.js'),
+  require('./export-named-declaration.js'),
   require('./expression-statement.js'),
   require('./function-declaration.js'),
   require('./function-expression.js'),


### PR DESCRIPTION
I've encountered an unwanted warning when you use a named export:
```javascript
export function calc() {
    doStuff();
}
```
Default exports were already supported so I figured it should be handled in the same way.
  