### PR TITLE
Handle import

### DIFF
--- a/jsdoc/services/code-name-matchers/import-declaration.js
+++ b/jsdoc/services/code-name-matchers/import-declaration.js
@@ -1,0 +1,13 @@
+/**
+ * @dgService ImportDeclarationNodeMatcher
+ * @description Creates code name matcher for AST entry
+ */
+module.exports = function ImportDeclarationNodeMatcherFactory () {
+  /**
+   * @param {Node} node AST node to process
+   * @returns {String|Null} code name from node
+   */
+  return function ImportDeclarationNodeMatcher (node) {
+    return node.source && node.source.value || null;
+  }
+};

--- a/jsdoc/services/code-name-matchers/import-declaration.spec.js
+++ b/jsdoc/services/code-name-matchers/import-declaration.spec.js
@@ -1,0 +1,19 @@
+var matcherFactory = require('./import-declaration');
+
+describe('ImportDeclaration matcher', function() {
+
+  var matcher;
+
+  beforeEach(function() {
+    matcher = matcherFactory();
+  });
+
+  it("should return null for unsupported nodes", function() {
+    expect(matcher({})).toBeNull();
+    expect(matcher({ source: {} })).toBeNull();
+  });
+
+  it("should return a name for supported nodes", function() {
+    expect(matcher({ source: { value: './file' } })).toBe('./file');
+  });
+});

--- a/jsdoc/services/code-name-matchers/index.js
+++ b/jsdoc/services/code-name-matchers/index.js
@@ -9,6 +9,7 @@ module.exports = [
   require('./function-declaration.js'),
   require('./function-expression.js'),
   require('./identifier.js'),
+  require('./import-declaration'),
   require('./literal.js'),
   require('./member-expression.js'),
   require('./method-definition.js'),


### PR DESCRIPTION
A fix for #250 

By looking at https://astexplorer.net/ I think this is the best way to get a good enough name out of all import statements.

This matcher should return the following:
```javascript
import './file';                     // returns null
import foo from './file';            // returns foo
import { foo } from './file';        // returns foo
import { foo, bar } from './file';   // returns foo
```