### PR TITLE
fix(typescript): fallback to decorators from set accessor

### DIFF
--- a/typescript/mocks/readTypeScriptModules/gettersAndSetters.ts
+++ b/typescript/mocks/readTypeScriptModules/gettersAndSetters.ts
@@ -17,4 +17,13 @@ export class Test {
   get noType() { return 'x'; }
   /** So we get it from the setter instead */
   set noType(value: string) { /**/ }
+
+  /** Description of myProperty. */
+  @SomeDecorator()
+  set decoratorProp(value: string) {}
+  get decoratorProp() { return 'Hello'; }
+}
+
+export function SomeDecorator() {
+  return (target: any, args: any) => {}
 }

--- a/typescript/src/api-doc-types/PropertyMemberDoc.ts
+++ b/typescript/src/api-doc-types/PropertyMemberDoc.ts
@@ -21,12 +21,23 @@ export class PropertyMemberDoc extends MemberDoc {
     setAccessorDeclaration: SetAccessorDeclaration | null,
     isStatic: boolean,
   ) {
+    // For accessors, the declaration parameter will be null, and therefore the getter declaration
+    // will be used for most of the things (e.g. determination of the type). If the getter doesn't 
+    // have a type or description, the setter will be checked manually later in this constructor.
     super(containerDoc, symbol, (declaration || getAccessorDeclaration || setAccessorDeclaration)!, isStatic);
 
     // If this property has accessors then compute the type based on that instead
     this.getAccessor = getAccessorDeclaration && new AccessorInfoDoc('get', this, getAccessorDeclaration);
     this.setAccessor = setAccessorDeclaration && new AccessorInfoDoc('set', this, setAccessorDeclaration);
-    this.type = this.type || this.setAccessor && this.setAccessor.parameterDocs[0].type || '';
-    this.content = this.content || this.setAccessor && this.setAccessor.content || '';
+
+    // As mentioned before, by default the get accessor declaration will be passed to the superclass,
+    // to determine information about the property. With that approach, it can happen that a few 
+    // things are not declared on the getter, but on the setter. In that case, if there is a
+    // setter, we add the missing information by looking at the setter info document.
+    if (this.setAccessor) {
+      this.type = this.type || this.setAccessor.parameterDocs[0].type || '';
+      this.content = this.content || this.setAccessor.content || '';
+      this.decorators = this.decorators || this.setAccessor.decorators;
+    }
   }
 }

--- a/typescript/src/processors/readTypeScriptModules/index.spec.ts
+++ b/typescript/src/processors/readTypeScriptModules/index.spec.ts
@@ -404,6 +404,9 @@ describe('readTypeScriptModules', () => {
       let noType: PropertyMemberDoc;
       let noTypeGetter: AccessorInfoDoc;
       let noTypeSetter: AccessorInfoDoc;
+      let decoratorProp: PropertyMemberDoc;
+      let decoratorPropGetter: AccessorInfoDoc;
+      let decoratorPropSetter: AccessorInfoDoc;
 
       beforeEach(() => {
         processor.sourceFiles = ['gettersAndSetters.ts'];
@@ -415,6 +418,7 @@ describe('readTypeScriptModules', () => {
         bar = docs.find(doc => doc.name === 'bar');
         qux = docs.find(doc => doc.name === 'qux');
         noType = docs.find(doc => doc.name === 'noType');
+        decoratorProp = docs.find(doc => doc.name === 'decoratorProp');
 
         foo1Getter = docs.find(doc => doc.name === 'foo1:get');
         foo1Setter = docs.find(doc => doc.name === 'foo1:set');
@@ -430,6 +434,9 @@ describe('readTypeScriptModules', () => {
 
         noTypeGetter = docs.find(doc => doc.name === 'noType:get');
         noTypeSetter = docs.find(doc => doc.name === 'noType:set');
+
+        decoratorPropGetter = docs.find(doc => doc.name === 'decoratorProp:get');
+        decoratorPropSetter = docs.find(doc => doc.name === 'decoratorProp:set');
       });
 
       it('should create a property member doc for property that has accessors', () => {
@@ -491,6 +498,20 @@ describe('readTypeScriptModules', () => {
         expect(bar.setAccessor).toBe(null);
         expect(qux.getAccessor).toBe(null);
         expect(qux.setAccessor).toBe(quxSetter);
+      });
+
+      describe('if getter is missing information', () => {
+        it('should add decorators of the setter to the property doc', () => {
+          expect(decoratorProp.decorators![0].name).toBe('SomeDecorator');
+        });
+
+        it('should add description of the setter to the property doc', () => {
+          expect(decoratorProp.content).toBe('Description of myProperty.');
+        });
+
+        it('should add type of the setter to the property doc', () => {
+          expect(decoratorProp.type).toBe('string');
+        });
       });
     });
 


### PR DESCRIPTION
Right now, decorators of accessor properties will be only taken from the get accessor. This is not the expected behavior, because it can also happen that decorators are placed on the setter.