### PR TITLE
Make gitRepoInfo() tolerant of internal repo URLs such as: http://foo…

### DIFF
--- a/git/mocks/mockPackageHttp.js
+++ b/git/mocks/mockPackageHttp.js
@@ -1,0 +1,20 @@
+var Package = require('dgeni').Package;
+var mocks = require('./mocks.js');
+
+module.exports = function mockPackage() {
+
+  return new Package('mockPackage', [require('../'), require('../../base')])
+
+  .factory('decorateVersion', function() { return mocks.decorateVersion })
+  .factory('getPreviousVersions', function() { return mocks.getPreviousVersions; })
+  .factory('gitData', function() { return mocks.gitData; })
+  .factory('gitRepoInfo', function() { return mocks.gitRepoInfo })
+  .factory('packageInfo', function() { return mocks.packageWithVersionHttp })
+  .factory('versionInfo', function() { return mocks.versionInfo })
+
+  // provide a mock log service
+  .factory('log', function() { return require('dgeni/lib/mocks/log')(false); })
+
+  // provide a mock template engine for the tests
+  .factory('templateEngine', function dummyTemplateEngine() {});
+};

--- a/git/mocks/mocks.js
+++ b/git/mocks/mocks.js
@@ -19,6 +19,15 @@ var packageWithBranchVersion = {
   }
 }
 
+var packageWithVersionHttp = {
+  "name": "dgeni-packages",
+  "version": "0.10.13",
+  "repository": {
+    "type": "git",
+    "url": "http://localhost:9999/owner-http/repo-http"
+  }
+}
+
 var mockVersionInfo = {
   currentVersion: 'currentVersion',
   previousVersions: 'previousVersions',
@@ -77,6 +86,7 @@ module.exports = {
   gitRepoInfo: mockGitRepoInfo,
   packageWithBranchVersion: packageWithBranchVersion,
   packageWithVersion: packageWithVersion,
+  packageWithVersionHttp: packageWithVersionHttp,
   versionInfo: mockVersionInfo,
   mockGitCatFile: mockGitCatFile,
   mockGitCatFileBadFormat: mockGitCatFileBadFormat,

--- a/git/services/gitRepoInfo.js
+++ b/git/services/gitRepoInfo.js
@@ -5,7 +5,7 @@
  * @return {Object} An object containing the github owner and repository name
  */
 module.exports = function gitRepoInfo(packageInfo) {
-  var GITURL_REGEX = /^(?:git\+https|https?):\/\/[^/]+\/([^/]+)\/(.+).git$/;
+  var GITURL_REGEX = /^(?:git\+https|https|http?):\/\/[^/]+\/([^/]+)\/([^\n.]+)(?:\.git)?$/;
   var match = GITURL_REGEX.exec(packageInfo.repository.url);
   return {
     owner: match[1],

--- a/git/services/gitRepoInfo.spec.js
+++ b/git/services/gitRepoInfo.spec.js
@@ -1,4 +1,5 @@
 var mockPackageFactory = require('../mocks/mockPackage');
+var mockPackageFactoryHttp = require('../mocks/mockPackageHttp');
 var Dgeni = require('dgeni');
 var gitRepoInfoFactory = require('./gitRepoInfo');
 
@@ -35,5 +36,16 @@ describe("gitRepoInfo", function() {
     var injector = dgeni.configureInjector();
 
     expect(function(){injector.get('gitRepoInfo')}).toThrow();
+  });
+
+  it("should have owner and repo set from package repository http url", function() {
+    var mockPackageHttp = mockPackageFactoryHttp()
+      .factory(gitRepoInfoFactory);
+    var dgeni = new Dgeni([mockPackageHttp]);
+    var injector = dgeni.configureInjector();
+
+    var gitRepoInfoHttp = injector.get('gitRepoInfo');
+    expect(gitRepoInfoHttp.owner).toBe('owner-http');
+    expect(gitRepoInfoHttp.repo).toBe('repo-http');
   });
 });


### PR DESCRIPTION
Make gitRepoInfo() tolerant of internal repo URLs such as: http://foo.bar.net:7999/projects/web/repos/foo-bar-project

Previously #216 

@petebacondarwin ^