### PR TITLE
chore: remove debugger statement

### DIFF
--- a/jsdoc/services/transforms/extract-type.spec.js
+++ b/jsdoc/services/transforms/extract-type.spec.js
@@ -11,7 +11,6 @@ describe("extract-type transform", function() {
   });
 
   it("should extract the type from the description", function() {
-    debugger;
     value = ' {string} paramName - Some description  \n Some more description';
     value = transform(doc, tag, value);
 


### PR DESCRIPTION
Removes an accidentally added debugger statement from 35763aafa89b85555ac122bcdd462f4452b1f51d