### PR TITLE
feat(typescript): add option to disable leading comment concatenation

### DIFF
--- a/typescript/mocks/tsParser/multipleLeadingComments.ts
+++ b/typescript/mocks/tsParser/multipleLeadingComments.ts
@@ -1,0 +1,10 @@
+/**
+ * Not a license comment.
+ */
+
+/**
+ * This is a test function
+ */
+export function test(a: string) {
+  return a;
+}

--- a/typescript/src/api-doc-types/AccessorInfoDoc.ts
+++ b/typescript/src/api-doc-types/AccessorInfoDoc.ts
@@ -1,4 +1,5 @@
 import { Declaration } from 'typescript';
+import { Host } from '../services/ts-host/host';
 import { MethodMemberDoc } from './MethodMemberDoc';
 import { PropertyMemberDoc } from './PropertyMemberDoc';
 
@@ -13,7 +14,10 @@ export class AccessorInfoDoc extends MethodMemberDoc {
   aliases = this.propertyDoc.aliases.map(alias => `${alias}:${this.accessorType}`);
   anchor = this.name;
 
-  constructor(public accessorType: 'get'|'set', public propertyDoc: PropertyMemberDoc, declaration: Declaration) {
-    super(propertyDoc.containerDoc, propertyDoc.symbol, declaration);
+  constructor(host: Host,
+              public accessorType: 'get'|'set',
+              public propertyDoc: PropertyMemberDoc,
+              declaration: Declaration) {
+    super(host, propertyDoc.containerDoc, propertyDoc.symbol, declaration);
   }
 }

--- a/typescript/src/api-doc-types/ApiDoc.ts
+++ b/typescript/src/api-doc-types/ApiDoc.ts
@@ -1,4 +1,5 @@
 import { Declaration, Symbol, TypeChecker } from 'typescript';
+import { Host } from '../services/ts-host/host';
 import { FileInfo } from '../services/TsParser/FileInfo';
 import { getContent } from '../services/TsParser/getContent';
 import { ModuleDoc } from './ModuleDoc';
@@ -31,7 +32,7 @@ export abstract class BaseApiDoc implements ApiDoc {
   startingLine = this.fileInfo.location.start.line +
     (this.fileInfo.location.start.character ? 1 : 0);
   endingLine = this.fileInfo.location.end.line;
-  content = getContent(this.declaration);
+  content = this.host.getContent(this.declaration);
   path: string = '';
   outputPath: string = '';
 
@@ -39,8 +40,10 @@ export abstract class BaseApiDoc implements ApiDoc {
     .replace(new RegExp("\." + this.fileInfo.extension + "$"), "");
   typeChecker: TypeChecker = this.moduleDoc.typeChecker;
 
-  constructor(public moduleDoc: ModuleDoc,
+  constructor(public host: Host,
+              public moduleDoc: ModuleDoc,
               public symbol: Symbol,
               public declaration: Declaration,
-              public aliasSymbol?: Symbol) {}
+              public aliasSymbol?: Symbol) {
+  }
 }

--- a/typescript/src/api-doc-types/ClassExportDoc.ts
+++ b/typescript/src/api-doc-types/ClassExportDoc.ts
@@ -4,6 +4,7 @@ import { ClassLikeExportDoc } from '../api-doc-types/ClassLikeExportDoc';
 import { MemberDoc } from '../api-doc-types/MemberDoc';
 import { MethodMemberDoc } from '../api-doc-types/MethodMemberDoc';
 import { ModuleDoc } from '../api-doc-types/ModuleDoc';
+import { Host } from '../services/ts-host/host';
 
 /**
  * Classes are Class-like but also can contain static members
@@ -15,11 +16,12 @@ export class ClassExportDoc extends ClassLikeExportDoc {
   statics: MemberDoc[] = [];
   isAbstract = this.declaration.modifiers && this.declaration.modifiers.some(modifier => modifier.kind === SyntaxKind.AbstractKeyword);
 
-  constructor(
-    moduleDoc: ModuleDoc,
-    symbol: Symbol,
-    aliasSymbol?: Symbol) {
-    super(moduleDoc, symbol, symbol.valueDeclaration!, aliasSymbol);
+  constructor(host: Host,
+              moduleDoc: ModuleDoc,
+              symbol: Symbol,
+              aliasSymbol?: Symbol) {
+    super(host, moduleDoc, symbol, symbol.valueDeclaration!, aliasSymbol);
+
     if (symbol.exports) {
       this.statics = this.getMemberDocs(symbol.exports, moduleDoc.hidePrivateMembers);
     }
@@ -41,10 +43,10 @@ export class ClassExportDoc extends ClassLikeExportDoc {
     constructorSymbol.getDeclarations()!.forEach(declaration => {
       if ((declaration as FunctionLikeDeclaration).body) {
         // This is the "real" declaration of the method
-        constructorDoc = new MethodMemberDoc(this, constructorSymbol, declaration, overloads);
+        constructorDoc = new MethodMemberDoc(this.host, this, constructorSymbol, declaration, overloads);
       } else {
         // This is an overload signature of the method
-        overloads.push(new MethodMemberDoc(this, constructorSymbol, declaration, overloads));
+        overloads.push(new MethodMemberDoc(this.host, this, constructorSymbol, declaration, overloads));
       }
     });
     return constructorDoc || overloads.shift();

--- a/typescript/src/api-doc-types/ClassLikeExportDoc.ts
+++ b/typescript/src/api-doc-types/ClassLikeExportDoc.ts
@@ -1,6 +1,15 @@
 /* tslint:disable:no-bitwise */
 /* tslint:disable:max-classes-per-file */
-import { Declaration, ExpressionWithTypeArguments, HeritageClause, Symbol, SymbolFlags, SyntaxKind, symbolName } from 'typescript';
+import {
+  Declaration,
+  ExpressionWithTypeArguments,
+  HeritageClause,
+  Symbol,
+  SymbolFlags,
+  symbolName,
+  SyntaxKind,
+} from 'typescript';
+import { Host } from '../services/ts-host/host';
 import { getDecorators, ParsedDecorator } from "../services/TsParser/getDecorators";
 import { getTypeText } from '../services/TsParser/getTypeText';
 
@@ -23,15 +32,15 @@ export abstract class ClassLikeExportDoc extends ContainerExportDoc {
   descendants: ClassLikeExportDoc[] = [];
   typeParams = this.computeTypeParams();
 
-  constructor(
-      moduleDoc: ModuleDoc,
-      symbol: Symbol,
-      declaration: Declaration,
-      aliasSymbol?: Symbol) {
-        super(moduleDoc, symbol, declaration, aliasSymbol);
-        this.computeHeritageClauses();
-        this.addAliases();
-      }
+  constructor(host: Host, moduleDoc: ModuleDoc,
+              symbol: Symbol,
+              declaration: Declaration,
+              aliasSymbol?: Symbol) {
+    super(host, moduleDoc, symbol, declaration, aliasSymbol);
+
+    this.computeHeritageClauses();
+    this.addAliases();
+  }
 
   private computeTypeParams() {
     if (this.symbol.members) {

--- a/typescript/src/api-doc-types/ConstExportDoc.ts
+++ b/typescript/src/api-doc-types/ConstExportDoc.ts
@@ -1,5 +1,5 @@
-import { Symbol, Type, TypeFormatFlags, VariableDeclaration } from 'typescript';
-import { getDeclarationTypeText } from '../services/TsParser/getDeclarationTypeText';
+import { Symbol, VariableDeclaration } from 'typescript';
+import { Host } from '../services/ts-host/host';
 import { ExportDoc } from './ExportDoc';
 import { ModuleDoc } from './ModuleDoc';
 
@@ -8,8 +8,11 @@ export class ConstExportDoc extends ExportDoc {
   variableDeclaration = this.declaration as VariableDeclaration;
   type =  this.getTypeString();
 
-  constructor(moduleDoc: ModuleDoc, symbol: Symbol, aliasSymbol?: Symbol) {
-    super(moduleDoc, symbol, symbol.valueDeclaration!, aliasSymbol);
+  constructor(host: Host,
+              moduleDoc: ModuleDoc,
+              symbol: Symbol,
+              aliasSymbol?: Symbol) {
+    super(host, moduleDoc, symbol, symbol.valueDeclaration!, aliasSymbol);
   }
 
   private getTypeString() {

--- a/typescript/src/api-doc-types/ContainerExportDoc.ts
+++ b/typescript/src/api-doc-types/ContainerExportDoc.ts
@@ -1,13 +1,12 @@
 /* tslint:disable:no-bitwise */
 import {
-    FunctionLikeDeclaration,
-    GetAccessorDeclaration,
-    Map,
-    SetAccessorDeclaration,
-    Symbol,
-    SymbolFlags,
-    SyntaxKind,
-    UnderscoreEscapedMap
+  FunctionLikeDeclaration,
+  GetAccessorDeclaration,
+  SetAccessorDeclaration,
+  Symbol,
+  SymbolFlags,
+  SyntaxKind,
+  UnderscoreEscapedMap,
 } from 'typescript';
 import { getAccessibility } from "../services/TsParser/getAccessibility";
 import { ExportDoc } from './ExportDoc';
@@ -56,13 +55,13 @@ export abstract class ContainerExportDoc extends ExportDoc {
             setAccessorDeclaration = declaration as SetAccessorDeclaration;
           } else if ((declaration as FunctionLikeDeclaration).body) {
             // This is the "real" declaration of the method
-            memberDoc = new MethodMemberDoc(this, member, declaration, overloads);
+            memberDoc = new MethodMemberDoc(this.host, this, member, declaration, overloads);
           } else {
             // This is an overload signature of the method
-            overloads.push(new MethodMemberDoc(this, member, declaration, overloads));
+            overloads.push(new MethodMemberDoc(this.host, this, member, declaration, overloads));
           }
         } else if (flags & PropertyMemberFlags) {
-          memberDoc = new PropertyMemberDoc(this, member, declaration, null, null);
+          memberDoc = new PropertyMemberDoc(this.host, this, member, declaration, null, null);
         } else {
           throw new Error(`Unknown member type for member ${member.name}`);
         }
@@ -70,7 +69,8 @@ export abstract class ContainerExportDoc extends ExportDoc {
 
       // If at least one of the declarations was an accessor then the whole member is a property.
       if (getAccessorDeclaration || setAccessorDeclaration) {
-        memberDoc = new PropertyMemberDoc(this, member, null, getAccessorDeclaration, setAccessorDeclaration);
+        memberDoc = new PropertyMemberDoc(this.host, this, member, null, getAccessorDeclaration,
+            setAccessorDeclaration);
       }
 
       // If there is no member doc then we are in an interface or abstract class and we just take the first overload

--- a/typescript/src/api-doc-types/EnumExportDoc.ts
+++ b/typescript/src/api-doc-types/EnumExportDoc.ts
@@ -1,4 +1,5 @@
 import { Declaration, Symbol } from 'typescript';
+import { Host } from '../services/ts-host/host';
 import { ContainerExportDoc } from './ContainerExportDoc';
 import { ModuleDoc } from './ModuleDoc';
 
@@ -9,11 +10,12 @@ import { ModuleDoc } from './ModuleDoc';
 export class EnumExportDoc extends ContainerExportDoc {
   docType = 'enum';
   additionalDeclarations: Declaration[] = [];
-  constructor(
-    moduleDoc: ModuleDoc,
-    symbol: Symbol,
-    aliasSymbol?: Symbol) {
-    super(moduleDoc, symbol, symbol.valueDeclaration!, aliasSymbol);
+  constructor(host: Host,
+              moduleDoc: ModuleDoc,
+              symbol: Symbol,
+              aliasSymbol?: Symbol) {
+    super(host, moduleDoc, symbol, symbol.valueDeclaration!, aliasSymbol);
+
     this.additionalDeclarations = symbol.getDeclarations()!.filter(declaration => declaration !== this.declaration);
     if (symbol.exports) {
       this.members = this.getMemberDocs(symbol.exports, true);

--- a/typescript/src/api-doc-types/FunctionExportDoc.ts
+++ b/typescript/src/api-doc-types/FunctionExportDoc.ts
@@ -1,4 +1,5 @@
 import { Declaration, Symbol } from 'typescript';
+import { Host } from '../services/ts-host/host';
 import { getDeclarationTypeText } from '../services/TsParser/getDeclarationTypeText';
 import { ModuleDoc } from './ModuleDoc';
 import { OverloadInfo } from './OverloadInfo';
@@ -18,11 +19,13 @@ export class FunctionExportDoc extends ParameterizedExportDoc implements Paramet
   readonly parameterDocs: ParameterDoc[] = getParameters(this);
   readonly parameters = this.parameterDocs.map(p => p.paramText);
 
-  constructor(
-      public containerDoc: ModuleDoc,
-      symbol: Symbol,
-      aliasSymbol?: Symbol) {
-    super(containerDoc, symbol, findRealDeclaration(symbol.getDeclarations()!), aliasSymbol);
+  constructor(host: Host,
+              public containerDoc: ModuleDoc,
+              symbol: Symbol,
+              aliasSymbol?: Symbol) {
+
+    super(host, containerDoc, symbol, findRealDeclaration(symbol.getDeclarations()!),
+        aliasSymbol);
   }
 
 }

--- a/typescript/src/api-doc-types/InterfaceExportDoc.ts
+++ b/typescript/src/api-doc-types/InterfaceExportDoc.ts
@@ -1,6 +1,7 @@
 import { Declaration, Symbol } from 'typescript';
 import { ClassLikeExportDoc } from '../api-doc-types/ClassLikeExportDoc';
 import { ModuleDoc } from '../api-doc-types/ModuleDoc';
+import { Host } from '../services/ts-host/host';
 
 /**
  * Interfaces are class-like but can also have multiple declarations that are merged together
@@ -8,12 +9,20 @@ import { ModuleDoc } from '../api-doc-types/ModuleDoc';
 export class InterfaceExportDoc extends ClassLikeExportDoc {
   docType = 'interface';
   additionalDeclarations: Declaration[] = [];
-  constructor(
-    moduleDoc: ModuleDoc,
-    symbol: Symbol,
-    aliasSymbol?: Symbol) {
-      super(moduleDoc, symbol, symbol.valueDeclaration || symbol.getDeclarations()![0]!, aliasSymbol);
-      if (symbol.members) this.members = this.getMemberDocs(symbol.members, true);
-      this.additionalDeclarations = symbol.getDeclarations()!.filter(declaration => declaration !== this.declaration);
+
+  constructor(host: Host,
+              moduleDoc: ModuleDoc,
+              symbol: Symbol,
+              aliasSymbol?: Symbol) {
+
+      super(host, moduleDoc, symbol, symbol.valueDeclaration || symbol.getDeclarations()![0]!,
+          aliasSymbol);
+
+      if (symbol.members) {
+        this.members = this.getMemberDocs(symbol.members, true);
+      }
+
+      this.additionalDeclarations = symbol.getDeclarations()!
+        .filter(declaration => declaration !== this.declaration);
     }
 }

--- a/typescript/src/api-doc-types/MemberDoc.ts
+++ b/typescript/src/api-doc-types/MemberDoc.ts
@@ -1,8 +1,8 @@
 /* tslint:disable:no-bitwise */
 import { Declaration, Symbol, SymbolFlags, SyntaxKind, TypeChecker } from 'typescript';
+import { Host } from '../services/ts-host/host';
 import { FileInfo } from '../services/TsParser/FileInfo';
 import { getAccessibility } from "../services/TsParser/getAccessibility";
-import { getContent } from "../services/TsParser/getContent";
 import { getDeclarationTypeText } from "../services/TsParser/getDeclarationTypeText";
 import { getDecorators, ParsedDecorator } from "../services/TsParser/getDecorators";
 import { ApiDoc } from './ApiDoc';
@@ -22,7 +22,7 @@ export abstract class MemberDoc implements ApiDoc {
 
   path: string = '';
   outputPath: string = '';
-  content = getContent(this.declaration);
+  content = this.host.getContent(this.declaration);
   basePath = this.containerDoc.basePath;
   fileInfo = new FileInfo(this.declaration, this.basePath);
   startingLine = this.fileInfo.location.start.line + (this.fileInfo.location.start.character ? 1 : 0);
@@ -43,6 +43,7 @@ export abstract class MemberDoc implements ApiDoc {
   isStatic = !!this.declaration.modifiers && this.declaration.modifiers.some(modifier => modifier.kind === SyntaxKind.StaticKeyword);
 
   constructor(
+      public host: Host,
       public containerDoc: ContainerExportDoc,
       public symbol: Symbol,
       public declaration: Declaration) {

--- a/typescript/src/api-doc-types/MethodMemberDoc.ts
+++ b/typescript/src/api-doc-types/MethodMemberDoc.ts
@@ -1,5 +1,6 @@
 /* tslint:disable:no-bitwise */
 import { Declaration, Symbol } from 'typescript';
+import { Host } from '../services/ts-host/host';
 import { getTypeParametersText } from '../services/TsParser/getTypeParametersText';
 import { ContainerExportDoc } from './ContainerExportDoc';
 import { MemberDoc } from './MemberDoc';
@@ -15,12 +16,14 @@ export class MethodMemberDoc extends MemberDoc implements ParameterContainer {
   readonly aliases = this.computeAliases();
   readonly typeParameters = getTypeParametersText(this.declaration);
 
-  constructor(
-    containerDoc: ContainerExportDoc,
-    symbol: Symbol,
-    declaration: Declaration,
-    public overloads: MethodMemberDoc[] = []) {
-    super(containerDoc, symbol, declaration);
+  constructor(host: Host,
+              containerDoc: ContainerExportDoc,
+              symbol: Symbol,
+              declaration: Declaration,
+              public overloads: MethodMemberDoc[] = []) {
+
+    super(host, containerDoc, symbol, declaration);
+
     // fix up parameter ids and aliases, now that we have computed the id for this doc
     this.parameterDocs.forEach(param => {
       param.id = `${this.id}~${param.name}`;

--- a/typescript/src/api-doc-types/ModuleDoc.ts
+++ b/typescript/src/api-doc-types/ModuleDoc.ts
@@ -23,5 +23,8 @@ export class ModuleDoc implements ApiDoc {
   outputPath: string = '';
   content: string = '';
 
-  constructor(public symbol: ModuleSymbol, public basePath: string, public hidePrivateMembers: boolean, public typeChecker: TypeChecker) {}
+  constructor(public symbol: ModuleSymbol,
+              public basePath: string,
+              public hidePrivateMembers: boolean,
+              public typeChecker: TypeChecker) {}
 }

--- a/typescript/src/api-doc-types/OverloadInfo.ts
+++ b/typescript/src/api-doc-types/OverloadInfo.ts
@@ -1,10 +1,10 @@
 import { Declaration } from 'typescript';
 import { getDeclarationTypeText } from '../services/TsParser/getDeclarationTypeText';
+import { BaseApiDoc } from './ApiDoc';
 import { FunctionExportDoc } from './FunctionExportDoc';
 import { ModuleDoc } from './ModuleDoc';
 import { getParameters, ParameterContainer } from './ParameterContainer';
 import { ParameterDoc } from './ParameterDoc';
-import { BaseApiDoc } from './ApiDoc';
 
 /**
  * This represents a single overload of an exported function.
@@ -20,7 +20,8 @@ export class OverloadInfo extends BaseApiDoc implements ParameterContainer {
   containerDoc: ModuleDoc = this.functionDoc.containerDoc;
 
   constructor(public functionDoc: FunctionExportDoc, declaration: Declaration) {
-    super(functionDoc.moduleDoc, functionDoc.symbol, declaration);
+    super(functionDoc.host, functionDoc.moduleDoc, functionDoc.symbol, declaration);
+
     // Give this overload doc a more specific id and aliases than it's container doc
     const paramString = `(${this.parameters.join(', ')})`;
     this.id += paramString;

--- a/typescript/src/api-doc-types/ParameterContainer.ts
+++ b/typescript/src/api-doc-types/ParameterContainer.ts
@@ -1,4 +1,5 @@
-import { Declaration,ParameterDeclaration, SignatureDeclaration, TypeChecker } from 'typescript';
+import { Declaration, ParameterDeclaration, SignatureDeclaration, TypeChecker } from 'typescript';
+import { Host } from '../services/ts-host/host';
 import { nodeToString } from '../services/TsParser/nodeToString';
 import { ContainerExportDoc } from './ContainerExportDoc';
 import { ModuleDoc } from './ModuleDoc';
@@ -24,6 +25,7 @@ export interface ParameterContainer {
   declaration: Declaration;
   basePath: string;
   typeChecker: TypeChecker;
+  host: Host;
   params?: ParamTag[];
 }
 
@@ -37,6 +39,6 @@ export function getParameters(callableDoc: ParameterContainer) {
   }
 
   return signature.getParameters().map(parameter => {
-    return new ParameterDoc(callableDoc, parameter, parameter.valueDeclaration as ParameterDeclaration)
+    return new ParameterDoc(callableDoc, parameter, parameter.valueDeclaration as ParameterDeclaration);
   });
 }

--- a/typescript/src/api-doc-types/ParameterDoc.ts
+++ b/typescript/src/api-doc-types/ParameterDoc.ts
@@ -1,6 +1,5 @@
-import { Declaration, ParameterDeclaration, Symbol, SymbolFlags } from 'typescript';
-import { getDeclarationTypeText, getInitializer } from '../services/TsParser/getDeclarationTypeText';
-import { getTypeText } from '../services/TsParser/getTypeText';
+import { ParameterDeclaration, Symbol } from 'typescript';
+import { getDeclarationTypeText } from '../services/TsParser/getDeclarationTypeText';
 import { nodeToString } from '../services/TsParser/nodeToString';
 import { BaseApiDoc } from './ApiDoc';
 import { ParameterContainer } from './ParameterContainer';
@@ -22,7 +21,7 @@ export class ParameterDoc extends BaseApiDoc {
   constructor(public container: ParameterContainer,
               public symbol: Symbol,
               public declaration: ParameterDeclaration) {
-    super(container.moduleDoc, symbol, declaration);
+    super(container.host, container.moduleDoc, symbol, declaration);
 
     this.id = `${this.container.id}~${this.name}`;
     this.aliases = (this.container.aliases || []).map(alias => `${alias}~${this.name}`);

--- a/typescript/src/api-doc-types/ParameterizedExportDoc.ts
+++ b/typescript/src/api-doc-types/ParameterizedExportDoc.ts
@@ -1,4 +1,5 @@
 import { Declaration, Symbol } from 'typescript';
+import { Host } from '../services/ts-host/host';
 import { getTypeParametersText } from '../services/TsParser/getTypeParametersText';
 import { ExportDoc } from './ExportDoc';
 import { ModuleDoc } from './ModuleDoc';
@@ -6,11 +7,12 @@ import { ModuleDoc } from './ModuleDoc';
 export abstract class ParameterizedExportDoc extends ExportDoc {
   typeParameters = getTypeParametersText(this.declaration);
 
-  constructor(moduleDoc: ModuleDoc,
+  constructor(host: Host,
+              moduleDoc: ModuleDoc,
               symbol: Symbol,
               declaration: Declaration,
               aliasSymbol?: Symbol) {
 
-    super(moduleDoc, symbol, declaration, aliasSymbol);
+    super(host, moduleDoc, symbol, declaration, aliasSymbol);
   }
 }

--- a/typescript/src/api-doc-types/PropertyMemberDoc.ts
+++ b/typescript/src/api-doc-types/PropertyMemberDoc.ts
@@ -1,4 +1,5 @@
 import { Declaration, GetAccessorDeclaration, SetAccessorDeclaration, Symbol } from 'typescript';
+import { Host } from '../services/ts-host/host';
 import { AccessorInfoDoc } from './AccessorInfoDoc';
 import { ContainerExportDoc } from './ContainerExportDoc';
 import { MemberDoc } from './MemberDoc';
@@ -11,7 +12,8 @@ export class PropertyMemberDoc extends MemberDoc {
   getAccessor: AccessorInfoDoc | null;
   setAccessor: AccessorInfoDoc | null;
 
-  constructor(containerDoc: ContainerExportDoc,
+  constructor(host: Host,
+              containerDoc: ContainerExportDoc,
               symbol: Symbol,
               declaration: Declaration | null,
               getAccessorDeclaration: GetAccessorDeclaration | null,
@@ -20,11 +22,11 @@ export class PropertyMemberDoc extends MemberDoc {
     // For accessors, the declaration parameter will be null, and therefore the getter declaration
     // will be used for most of the things (e.g. determination of the type). If the getter doesn't
     // have a type or description, the setter will be checked manually later in this constructor.
-    super(containerDoc, symbol, (declaration || getAccessorDeclaration || setAccessorDeclaration)!);
+    super(host, containerDoc, symbol, (declaration || getAccessorDeclaration || setAccessorDeclaration)!);
 
     // If this property has accessors then compute the type based on that instead
-    this.getAccessor = getAccessorDeclaration && new AccessorInfoDoc('get', this, getAccessorDeclaration);
-    this.setAccessor = setAccessorDeclaration && new AccessorInfoDoc('set', this, setAccessorDeclaration);
+    this.getAccessor = getAccessorDeclaration && new AccessorInfoDoc(host, 'get', this, getAccessorDeclaration);
+    this.setAccessor = setAccessorDeclaration && new AccessorInfoDoc(host, 'set', this, setAccessorDeclaration);
 
     // As mentioned before, by default the get accessor declaration will be passed to the superclass,
     // to determine information about the property. With that approach, it can happen that a few

--- a/typescript/src/api-doc-types/TypeAliasExportDoc.ts
+++ b/typescript/src/api-doc-types/TypeAliasExportDoc.ts
@@ -1,4 +1,5 @@
 import { Declaration, Symbol, SyntaxKind } from 'typescript';
+import { Host } from '../services/ts-host/host';
 import { getDeclarationTypeText } from '../services/TsParser/getDeclarationTypeText';
 import { ModuleDoc } from './ModuleDoc';
 import { ParameterizedExportDoc } from './ParameterizedExportDoc';
@@ -7,11 +8,13 @@ export class TypeAliasExportDoc extends ParameterizedExportDoc {
   docType = 'type-alias';
   typeDefinition = getDeclarationTypeText(this.declaration);
 
-  constructor(
-    moduleDoc: ModuleDoc,
-    exportSymbol: Symbol,
-    aliasSymbol?: Symbol) {
-    super(moduleDoc, exportSymbol, getTypeAliasDeclaration(exportSymbol.getDeclarations()!), aliasSymbol);
+  constructor(host: Host,
+              moduleDoc: ModuleDoc,
+              exportSymbol: Symbol,
+              aliasSymbol?: Symbol) {
+
+    super(host, moduleDoc, exportSymbol, getTypeAliasDeclaration(exportSymbol.getDeclarations()!),
+        aliasSymbol);
   }
 }
 

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -6,6 +6,7 @@ import { readTypeScriptModules } from './processors/readTypeScriptModules';
 import { convertPrivateClassesToInterfaces } from './services/convertPrivateClassesToInterfaces';
 import { exportSymbolsToDocsMap } from './services/exportSymbolsToDocsMap';
 import { modules } from './services/modules';
+import { Host } from './services/ts-host/host';
 import { TsParser } from './services/TsParser';
 
 // Define the dgeni package for generating the docs
@@ -14,6 +15,7 @@ module.exports = new Package('typescript', [require('../jsdoc')])
 // Register the services and file readers
 .factory(modules)
 .factory(exportSymbolsToDocsMap)
+.factory('tsHost', () => new Host())
 .factory('tsParser', function(log) { return new TsParser(log); })
 
 .factory('convertPrivateClassesToInterfaces', function() { return convertPrivateClassesToInterfaces; })

--- a/typescript/src/services/TsParser/getContent.spec.ts
+++ b/typescript/src/services/TsParser/getContent.spec.ts
@@ -29,4 +29,19 @@ describe('getContent', () => {
     expect(getContent(method)).toEqual('Some method');
     expect(getContent(method.parameters[0])).toEqual('param 1');
   });
+
+  it('should properly concatenate multiple leading comments', () => {
+    const parseInfo = parser.parse(['tsParser/multipleLeadingComments.ts'], basePath);
+    const module = parseInfo.moduleSymbols[0];
+
+    expect(getContent(module.exportArray[0].getDeclarations()![0])).toEqual('Not a license comment.\nThis is a test function');
+  });
+
+  it('should be able to disable leading comments concatenation', () => {
+    const parseInfo = parser.parse(['tsParser/multipleLeadingComments.ts'], basePath);
+    const module = parseInfo.moduleSymbols[0];
+
+    expect(getContent(module.exportArray[0].getDeclarations()![0], false))
+        .toEqual('This is a test function');
+  });
 });

--- a/typescript/src/services/convertPrivateClassesToInterfaces.spec.ts
+++ b/typescript/src/services/convertPrivateClassesToInterfaces.spec.ts
@@ -1,8 +1,9 @@
-import { createSourceFile, ScriptTarget } from 'typescript';
 import { DocCollection } from 'dgeni';
+import { createSourceFile, ScriptTarget } from 'typescript';
 import { ClassExportDoc } from '../api-doc-types/ClassExportDoc';
 import { HeritageInfo } from '../api-doc-types/ClassLikeExportDoc';
 import { convertPrivateClassesToInterfaces } from './convertPrivateClassesToInterfaces';
+import { Host } from './ts-host/host';
 import { FileInfo } from './TsParser/FileInfo';
 
 describe('convertPrivateClassesToInterfaces', () => {
@@ -21,7 +22,7 @@ describe('convertPrivateClassesToInterfaces', () => {
   beforeEach(() => {
     spyOn(FileInfo.prototype, 'getRealFilePath').and.callFake((filePath: string) => filePath);
 
-    classDoc = new ClassExportDoc(moduleDoc, classSymbol);
+    classDoc = new ClassExportDoc(new Host(), moduleDoc, classSymbol);
     classDoc.constructorDoc = { internal: true } as any;
     docs = [classDoc];
   });

--- a/typescript/src/services/convertPrivateClassesToInterfaces.ts
+++ b/typescript/src/services/convertPrivateClassesToInterfaces.ts
@@ -1,25 +1,33 @@
-import { DocCollection } from 'dgeni';
+import { DocCollection, Document } from 'dgeni';
+import { ClassExportDoc } from '../api-doc-types/ClassExportDoc';
 import { ConstExportDoc } from '../api-doc-types/ConstExportDoc';
+
 export function convertPrivateClassesToInterfaces(exportDocs: DocCollection, addInjectableReference: boolean) {
 
   exportDocs.forEach(exportDoc => {
 
     // Search for classes with a constructor marked as `@internal`
-    if (exportDoc.docType === 'class' && exportDoc.constructorDoc && exportDoc.constructorDoc.internal) {
-
+    if (isPrivateClassExportDoc(exportDoc)) {
       // Convert this class to an interface with no constructor
       exportDoc.docType = 'interface';
-      exportDoc.constructorDoc = null;
+      exportDoc.constructorDoc = undefined;
 
       // convert the heritage since interfaces use `extends` not `implements`
       exportDoc.extendsClauses = exportDoc.extendsClauses.concat(exportDoc.implementsClauses);
 
       if (addInjectableReference) {
         // Add the `declare var SomeClass extends InjectableReference` construct
-        const constExportDoc = new ConstExportDoc(exportDoc.moduleDoc, exportDoc.symbol);
+        const constExportDoc = new ConstExportDoc(exportDoc.host, exportDoc.moduleDoc,
+            exportDoc.symbol, exportDoc.aliasSymbol);
+
         constExportDoc.type = 'InjectableReference';
         exportDocs.push(constExportDoc);
       }
     }
   });
+}
+
+/** Whether the specified document is a class document with an internal constructor. */
+function isPrivateClassExportDoc(doc: Document): doc is ClassExportDoc {
+  return doc.docType === 'class' && doc.constructorDoc && doc.constructorDoc.internal;
 }

--- a/typescript/src/services/ts-host/host.spec.ts
+++ b/typescript/src/services/ts-host/host.spec.ts
@@ -1,0 +1,51 @@
+import { Dgeni, Package } from 'dgeni';
+import { TsParser } from '../TsParser';
+import { Host } from './host';
+
+const mockPackage = require('../../mocks/mockPackage');
+const path = require('canonical-path');
+
+describe('Host', () => {
+  const basePath = path.resolve(__dirname, '../../mocks/tsParser');
+
+  let host: Host;
+  let parser: TsParser;
+
+  /**
+   * Creates the Host instance through Dgeni dependency injection. Also allows passing a function
+   * that will run in Dgeni's configuration lifecycle and allows modifying the host factory.
+   */
+  function setupTestDgeniInstance(configureFn: (host: Host) => void) {
+    const testPackage = mockPackage() as Package;
+
+    testPackage.config((tsHost: Host) => configureFn(tsHost));
+
+    const dgeni = new Dgeni([testPackage]);
+    const injector = dgeni.configureInjector();
+
+    // Load factories from the Dgeni injector.
+    host = injector.get('tsHost');
+    parser = injector.get('tsParser');
+  }
+
+  it("should read content of a declaration", () => {
+    setupTestDgeniInstance(h => h.concatMultipleLeadingComments = true);
+
+    const parseInfo = parser.parse(['multipleLeadingComments.ts'], basePath);
+    const module = parseInfo.moduleSymbols[0];
+    const declaration = module.exportArray[0].valueDeclaration!;
+
+    expect(host.getContent(declaration))
+      .toEqual('Not a license comment.\nThis is a test function');
+  });
+
+  it('should be able to disable leading comment concatenation', () => {
+    setupTestDgeniInstance(h => h.concatMultipleLeadingComments = false);
+
+    const parseInfo = parser.parse(['multipleLeadingComments.ts'], basePath);
+    const module = parseInfo.moduleSymbols[0];
+    const declaration = module.exportArray[0].valueDeclaration!;
+
+    expect(host.getContent(declaration)).toEqual('This is a test function');
+  });
+});

--- a/typescript/src/services/ts-host/host.ts
+++ b/typescript/src/services/ts-host/host.ts
@@ -1,0 +1,17 @@
+import {Declaration} from 'typescript';
+import {getContent} from '../TsParser';
+
+/**
+ * Host that will be used for TypeScript AST operations that should be configurable or shared
+ * across multiple doc types.
+ */
+export class Host {
+
+  /** Whether multiple leading comments for a TypeScript node should be concatenated. */
+  concatMultipleLeadingComments: boolean = true;
+
+  getContent(declaration: Declaration) {
+    return getContent(declaration, this.concatMultipleLeadingComments);
+  }
+
+}


### PR DESCRIPTION
Introduces a new option that allows developers to configure the `tsHost` to not concatenate multiple leading comments for a `TypeScript` node content.

The `tsHost` is a newly created service that delegates (for now) to the `tsParser` package for retrieving the content of a given node. The advantage of the `tsHost` is that people can inject the `tsHost` in Dgeni `.config()` and specify options or overwrite methods.

Related angular/material2#12736.