### PR TITLE
fix(jsdoc): support void/self-closing/custom HTML tags

### DIFF
--- a/jsdoc/services/parser-adapters/html-block-parser-adapter.js
+++ b/jsdoc/services/parser-adapters/html-block-parser-adapter.js
@@ -1,19 +1,21 @@
-const TAG_REGEXP = /^<([a-zA-Z]+)\b[\s\S]*?>/;
+const TAG_REGEXP = /^<([a-z-A-Z]+)\b[^>]*>/;
+const VOID_TAGS = [ 'area', 'base', 'basefont', 'bgsound', 'br', 'col', 'command', 'embed', 'frame', 'hr', 'image', 'img', 'input', 'isindex', 'keygen', 'link', 'menuitem', 'meta', 'nextid', 'param', 'source', 'track', 'wbr' ];
 /**
  * A ParserAdapter adapter that ignores tags between HTML blocks that would be ignored by markdown
  * See https://daringfireball.net/projects/markdown/syntax#html
  */
 module.exports = function htmlBlockParserAdapter() {
   return {
-    init: function(lines) {
+    voidTags: VOID_TAGS,
+    init(lines) {
       this.lines = lines;
       this.tagDepth = 0;
       this.currentTag = null;
     },
-    nextLine: function(line, lineNumber) {
+    nextLine(line, lineNumber) {
       if (this.tagDepth === 0 && this.lines[lineNumber - 1] === '') {
         const m = TAG_REGEXP.exec(line);
-        if (m) {
+        if (m && this.voidTags.indexOf(m[1]) === -1) {
           this.currentTag = m[1];
         }
       }
@@ -24,7 +26,7 @@ module.exports = function htmlBlockParserAdapter() {
         this.currentTag = null;
       }
     },
-    parseForTags: function() {
+    parseForTags() {
       return !this.currentTag;
     }
   };

--- a/jsdoc/services/parser-adapters/html-block-parser-adapter.spec.js
+++ b/jsdoc/services/parser-adapters/html-block-parser-adapter.spec.js
@@ -68,4 +68,145 @@ describe('htmlBlockParserAdapter', function() {
     adapter.nextLine(lines[4], 4);
     expect(adapter.parseForTags()).toBeTruthy();
   });
+
+  it("should ignore @tags inside inline custom HTML tag blocks", function() {
+    const adapter = htmlBlockParserAdapterFactory();
+    const lines = [
+      '@a some text',
+      '',
+      '<my-component>',
+      '<div>some content</div>',
+      '<div>',
+      '    @b not a tag',
+      '</div>',
+      '@c still not a tag',
+      '',
+      '</my-component> // closing tag',
+      '',
+      '@b is a tag'
+    ];
+    adapter.init && adapter.init(lines, new TagCollection());
+
+    adapter.nextLine(lines[0], 0);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[1], 1);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[2], 2);
+    expect(adapter.parseForTags()).toBeFalsy();
+    adapter.nextLine(lines[3], 3);
+    expect(adapter.parseForTags()).toBeFalsy();
+    adapter.nextLine(lines[4], 4);
+    expect(adapter.parseForTags()).toBeFalsy();
+    adapter.nextLine(lines[5], 5);
+    expect(adapter.parseForTags()).toBeFalsy();
+    adapter.nextLine(lines[6], 6);
+    expect(adapter.parseForTags()).toBeFalsy();
+    adapter.nextLine(lines[7], 7);
+    expect(adapter.parseForTags()).toBeFalsy();
+    adapter.nextLine(lines[8], 8);
+    expect(adapter.parseForTags()).toBeFalsy();
+    adapter.nextLine(lines[9], 9);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[10], 10);
+    expect(adapter.parseForTags()).toBeTruthy();
+  });
+
+
+  it("should cope with self-closing HTML tags", function() {
+    const adapter = htmlBlockParserAdapterFactory();
+    const lines = [
+      '@a some text',
+      '',
+      '<hr />',
+      '',
+      '@a some text after the HTML tag',
+    ];
+
+    adapter.init(lines, new TagCollection());
+
+    adapter.nextLine(lines[0], 0);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[1], 1);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[2], 2);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[3], 3);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[4], 4);
+    expect(adapter.parseForTags()).toBeTruthy();
+  });
+
+  const VOID_TAGS = [ 'area', 'base', 'basefont', 'bgsound', 'br', 'col', 'command', 'embed', 'frame', 'hr', 'image', 'img', 'input', 'isindex', 'keygen', 'link', 'menuitem', 'meta', 'nextid', 'param', 'source', 'track', 'wbr' ];
+  VOID_TAGS.forEach(tag => it(`should cope with default void HTML tags (${tag})`, function() {
+    const adapter = htmlBlockParserAdapterFactory();
+    const lines = [
+      '@a some text',
+      '',
+      `<${tag}>`,
+      '',
+      '<div>',
+      'ignore me',
+      '</div>',
+      '',
+      '@a some text after the HTML tag',
+    ];
+
+    adapter.init(lines, new TagCollection());
+
+    adapter.nextLine(lines[0], 0);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[1], 1);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[2], 2);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[3], 3);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[4], 4);
+    expect(adapter.parseForTags()).toBeFalsy();
+    adapter.nextLine(lines[5], 5);
+    expect(adapter.parseForTags()).toBeFalsy();
+    adapter.nextLine(lines[6], 6);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[7], 7);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[8], 8);
+    expect(adapter.parseForTags()).toBeTruthy();
+  }));
+
+  it('should support custom void tags', () => {
+    const adapter = htmlBlockParserAdapterFactory();
+    adapter.voidTags = ['custom'];
+    const lines = [
+      '@a some text',
+      '',
+      `<custom>`,
+      '',
+      '<div>',
+      'ignore me',
+      '</div>',
+      '',
+      '@a some text after the HTML tag',
+    ];
+
+    adapter.init(lines, new TagCollection());
+
+    adapter.nextLine(lines[0], 0);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[1], 1);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[2], 2);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[3], 3);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[4], 4);
+    expect(adapter.parseForTags()).toBeFalsy();
+    adapter.nextLine(lines[5], 5);
+    expect(adapter.parseForTags()).toBeFalsy();
+    adapter.nextLine(lines[6], 6);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[7], 7);
+    expect(adapter.parseForTags()).toBeTruthy();
+    adapter.nextLine(lines[8], 8);
+    expect(adapter.parseForTags()).toBeTruthy();
+  });
 });


### PR DESCRIPTION
The parser is designed to ignore tags inside
HTML blocks, but it did not understand these
less particular kinds of HTML tags.

Fixes https://github.com/angular/angular.js/issues/16671