### PR TITLE
fix(typescript): do not throw if node does not have any comment

### DIFF
--- a/typescript/mocks/tsParser/multipleLeadingComments.ts
+++ b/typescript/mocks/tsParser/multipleLeadingComments.ts
@@ -8,3 +8,7 @@
 export function test(a: string) {
   return a;
 }
+
+export function withNoComment(b: string) {
+  return b;
+}

--- a/typescript/src/services/TsParser/getContent.spec.ts
+++ b/typescript/src/services/TsParser/getContent.spec.ts
@@ -44,4 +44,12 @@ describe('getContent', () => {
     expect(getContent(module.exportArray[0].getDeclarations()![0], false))
         .toEqual('This is a test function');
   });
+
+  it('should not throw if node does not have any leading comment', () => {
+    const parseInfo = parser.parse(['tsParser/multipleLeadingComments.ts'], basePath);
+    const module = parseInfo.moduleSymbols[0];
+
+    expect(() => getContent(module.exportArray[1].getDeclarations()![0], false))
+        .not.toThrow();
+  });
 });

--- a/typescript/src/services/TsParser/getContent.ts
+++ b/typescript/src/services/TsParser/getContent.ts
@@ -73,7 +73,7 @@ function getJSDocCommentRanges(node: Node, text: string, concatLeadingComments: 
 
     if (concatLeadingComments) {
       commentRanges.push(...leadingCommentRanges);
-    } else {
+    } else if (leadingCommentRanges.length) {
       commentRanges.push(leadingCommentRanges[leadingCommentRanges.length - 1]);
     }
 


### PR DESCRIPTION
* Due to bd748bb2867194e317e68d3331d0613a2bfafd97, calling `getContent` for a node which does not have any leading comment, leads to a runtime exception.