### PR TITLE
feat(typescript): improve declaration type text rendering

### DIFF
--- a/typescript/mocks/tsParser/getDeclarationTypeText.test.ts
+++ b/typescript/mocks/tsParser/getDeclarationTypeText.test.ts
@@ -1,8 +1,18 @@
+/* tslint:disable:max-classes-per-file */
+
 export const testConst = 42;
+
 export function testFunction<T>(param1: T[]): number {
   return 0;
 }
+
 export class TestClass<T> {
-  property: T[];
+  prop1: T[];
+  prop2 = new OtherClass<T>();
+  prop3: OtherClass<T, T> = new OtherClass();
   method(x: T): T { return x; }
+}
+
+export class OtherClass<T, K = T> {
+
 }

--- a/typescript/src/services/TsParser/getDeclarationTypeText.spec.ts
+++ b/typescript/src/services/TsParser/getDeclarationTypeText.spec.ts
@@ -15,15 +15,22 @@ describe('getDeclarationTypeText', () => {
     const parseInfo = parser.parse(['tsParser/getDeclarationTypeText.test.ts'], basePath);
     const moduleExports = parseInfo.moduleSymbols[0].exportArray;
 
-    expect(getDeclarationTypeText(moduleExports[0].getDeclarations()![0])).toEqual('42');
+    expect(getDeclarationTypeText(getExport('testConst').getDeclarations()![0])).toEqual('42');
 
-    const testFunction = moduleExports[1].getDeclarations()![0] as SignatureDeclaration;
+    const testFunction = getExport('testFunction').getDeclarations()![0] as SignatureDeclaration;
     expect(getDeclarationTypeText(testFunction)).toEqual('number');
     expect(getDeclarationTypeText(testFunction.parameters[0])).toEqual('T[]');
     expect(getDeclarationTypeText(testFunction.typeParameters![0])).toEqual('T');
 
-    const testClass = moduleExports[2];
-    expect(getDeclarationTypeText(testClass.members!.get('property' as __String)!.getDeclarations()![0])).toEqual('T[]');
+    const testClass = getExport('TestClass');
+    expect(getDeclarationTypeText(testClass.members!.get('prop1' as __String)!.getDeclarations()![0])).toEqual('T[]');
+    expect(getDeclarationTypeText(testClass.members!.get('prop2' as __String)!.getDeclarations()![0])).toEqual('OtherClass<T>');
+    expect(getDeclarationTypeText(testClass.members!.get('prop3' as __String)!.getDeclarations()![0])).toEqual('OtherClass<T, T>');
     expect(getDeclarationTypeText(testClass.members!.get('method'as __String)!.getDeclarations()![0])).toEqual('T');
+
+    function getExport(name: string) {
+      return moduleExports.find(e => e.name === name)!;
+    }
   });
 });
+

--- a/typescript/src/services/TsParser/getDeclarationTypeText.ts
+++ b/typescript/src/services/TsParser/getDeclarationTypeText.ts
@@ -1,26 +1,41 @@
-import { Declaration, Node, SyntaxKind, TypeNode, TypeParameterDeclaration } from 'typescript';
+import * as ts from 'typescript';
 import { getTypeText } from './getTypeText';
 import { nodeToString } from './nodeToString';
 
-export function getDeclarationTypeText(declaration: Declaration) {
+export function getDeclarationTypeText(declaration: ts.Declaration): string {
   // if the declaration has an explicit type then use that
   const type = getType(declaration);
   if (type) return getTypeText(type);
 
   // if the declaration is a type parameter then just use its textual value
-  if (declaration.kind === SyntaxKind.TypeParameter ) {
+  if (ts.isTypeParameterDeclaration(declaration)) {
     return nodeToString(declaration);
   }
 
   // if the declaration is being initialized then use the initialization value
   const initializer = getInitializer(declaration);
-  return initializer ? nodeToString(initializer) : '';
+  if (initializer) {
+    if (ts.isNewExpression(initializer)) {
+      return nodeToString(initializer.expression) + getTypeArgumentText(initializer);
+    } else {
+      return nodeToString(initializer);
+    }
+  }
+  return '';
 }
 
-function getType(declaration: Declaration) {
-  return (declaration as any).type as TypeNode;
+function getType(declaration: ts.Declaration) {
+  return (declaration as any).type as ts.TypeNode;
 }
 
-export function getInitializer(declaration: Declaration) {
-  return (declaration as any).initializer as Node;
+function getInitializer(declaration: ts.Declaration): ts.Expression|undefined {
+  return (declaration as any).initializer;
+}
+
+function getTypeArgumentText(initializer: ts.NewExpression) {
+  if (!initializer.typeArguments) {
+    return '';
+  }
+  const typeTexts = initializer.typeArguments.map(t => nodeToString(t));
+  return `<${ typeTexts.join(', ')}>`;
 }


### PR DESCRIPTION
Where a declaration is an initializer and its value is a
new instance of a class, then display the type of that
class.