### PR TITLE
fix(typescript): empty node description if first leading comment is single line trivia

### DIFF
--- a/typescript/mocks/tsParser/multipleLeadingComments.ts
+++ b/typescript/mocks/tsParser/multipleLeadingComments.ts
@@ -12,3 +12,17 @@ export function test(a: string) {
 export function withNoComment(b: string) {
   return b;
 }
+
+/** This is the real comment. */
+// This is a comment that shouldn't be documented.
+export function withLeadingSingleLineComment(c: string) {
+  return c;
+}
+
+/** This JSDoc comment should be ignored. */
+/** First real comment. */
+// Non js single line document
+/* Non JS-doc document. */
+export function withLeadingNonJsDocComment(c: string) {
+  return c;
+}

--- a/typescript/src/services/TsParser/getContent.spec.ts
+++ b/typescript/src/services/TsParser/getContent.spec.ts
@@ -37,19 +37,38 @@ describe('getContent', () => {
     expect(getContent(module.exportArray[0].getDeclarations()![0])).toEqual('Not a license comment.\nThis is a test function');
   });
 
-  it('should be able to disable leading comments concatenation', () => {
-    const parseInfo = parser.parse(['tsParser/multipleLeadingComments.ts'], basePath);
-    const module = parseInfo.moduleSymbols[0];
+  describe('leading comments concatenation disabled', () => {
 
-    expect(getContent(module.exportArray[0].getDeclarations()![0], false))
+    it('should be able to disable concatenation', () => {
+      const parseInfo = parser.parse(['tsParser/multipleLeadingComments.ts'], basePath);
+      const module = parseInfo.moduleSymbols[0];
+
+      expect(getContent(module.exportArray[0].getDeclarations()![0], false))
         .toEqual('This is a test function');
-  });
+    });
 
-  it('should not throw if node does not have any leading comment', () => {
-    const parseInfo = parser.parse(['tsParser/multipleLeadingComments.ts'], basePath);
-    const module = parseInfo.moduleSymbols[0];
+    it('should not throw if node does not have any leading comment', () => {
+      const parseInfo = parser.parse(['tsParser/multipleLeadingComments.ts'], basePath);
+      const module = parseInfo.moduleSymbols[0];
 
-    expect(() => getContent(module.exportArray[1].getDeclarations()![0], false))
+      expect(() => getContent(module.exportArray[1].getDeclarations()![0], false))
         .not.toThrow();
+    });
+
+    it('should skip leading single-line comments', () => {
+      const parseInfo = parser.parse(['tsParser/multipleLeadingComments.ts'], basePath);
+      const module = parseInfo.moduleSymbols[0];
+
+      expect(getContent(module.exportArray[2].getDeclarations()![0], false))
+        .toEqual('This is the real comment.');
+    });
+
+    it('should skip leading non-js multi line comments', () => {
+      const parseInfo = parser.parse(['tsParser/multipleLeadingComments.ts'], basePath);
+      const module = parseInfo.moduleSymbols[0];
+
+      expect(getContent(module.exportArray[3].getDeclarations()![0], false))
+        .toEqual('First real comment.');
+    });
   });
 });


### PR DESCRIPTION
In case the new `concatMultipleLeadingComments` is set to `false` and the first comment of a TypeScript node is a **single line** non-JSdoc comment, the node content will be empty.

This is because the first single line comment will taken as leading comment but then afterwards filtered because it doesn't start with `/**`.