### PR TITLE
fix(nunjucks): disable autoescape for marked tag

### DIFF
--- a/nunjucks/rendering/tags/marked.js
+++ b/nunjucks/rendering/tags/marked.js
@@ -6,6 +6,9 @@ module.exports = function markedNunjucksTag(trimIndentation, renderMarkdown) {
   return {
     tags: ['marked'],
 
+    /** Disable autoescape for this tag because the markdown tag renders HTML that shouldn't be escaped. */
+    autoescape: false,
+
     parse: function(parser, nodes) {
       parser.advanceAfterBlockEnd();
 
@@ -21,8 +24,8 @@ module.exports = function markedNunjucksTag(trimIndentation, renderMarkdown) {
       var indent = trimIndentation.calcIndent(contentString);
       var trimmedString = trimIndentation.trimIndent(contentString, indent);
       var markedString = renderMarkdown(trimmedString);
-      var reindentedString = trimIndentation.reindent(markedString, indent);
-      return reindentedString;
+
+      return trimIndentation.reindent(markedString, indent);
     }
   };
 };

--- a/nunjucks/rendering/tags/marked.spec.js
+++ b/nunjucks/rendering/tags/marked.spec.js
@@ -1,5 +1,6 @@
 var Dgeni = require('dgeni');
 var mockPackage = require('../../mocks/mockPackage');
+var nunjucks = require('nunjucks');
 
 describe("marked custom tag extension", function() {
   var extension;
@@ -58,6 +59,15 @@ describe("marked custom tag extension", function() {
       expect(tag.args[0]).toEqual(extension);
       expect(tag.args[1]).toEqual('process');
       expect(tag.args[3]).toEqual(['some content']);
+    });
+  });
+
+  describe('(when used with nunjucks)', () => {
+    it('should not escape the output of the tag, even if nunjucks is configured to escape output', () => {
+      var engine = new nunjucks.Environment(null, {autoescape: true});
+      engine.addExtension('marked', extension);
+      const renderedContent = engine.renderString('{% marked %}some `inline code`{% endmarked %}', {});
+      expect(renderedContent).toEqual('<p>some <code>inline code</code></p>\n');
     });
   });
 });


### PR DESCRIPTION
* Currently if `autoescape` is enabled for the whole Nunjucks rendering engine, the custom `marked` tag does incorrectly escape the rendered HTML content. Nunjucks introduced for such cases an option that allows disabling `autoescape` only for individual extensions. See: https://github.com/mozilla/nunjucks/pull/192

cc. @petebacondarwin 

**Note**: I wish we could have created a test for this, but the current tests are basically just mocks and the autoescaping is something that happens internally.