### PR TITLE
feat(typescript): allow specifying type format flags for api-doc-types

### DIFF
--- a/typescript/mocks/tsParser/typeToString.ts
+++ b/typescript/mocks/tsParser/typeToString.ts
@@ -1,0 +1,20 @@
+export const a = 'someString';
+
+export const b: number = -1;
+
+export const c = {
+  A: 'a',
+  B: 'b',
+  C: 'c',
+  D: 'd',
+  E: 'e',
+  F: 'f',
+  G: 'g',
+  H: 'h',
+  I: 'i',
+  J: 'j',
+  K: 'k',
+  L: 'l',
+  M: 'm',
+  N: 'n',
+};

--- a/typescript/src/api-doc-types/ConstExportDoc.ts
+++ b/typescript/src/api-doc-types/ConstExportDoc.ts
@@ -15,11 +15,15 @@ export class ConstExportDoc extends ExportDoc {
     super(host, moduleDoc, symbol, symbol.valueDeclaration!, aliasSymbol);
   }
 
-  private getTypeString() {
-    if (this.variableDeclaration.type) {
-      return this.typeChecker.typeToString(this.typeChecker.getTypeFromTypeNode(this.variableDeclaration.type));
-    } else if (this.variableDeclaration.initializer) {
-      return this.typeChecker.typeToString(this.typeChecker.getTypeAtLocation(this.variableDeclaration.initializer));
+  private getTypeString(): string | undefined {
+    if (!this.variableDeclaration.type && !this.variableDeclaration.initializer) {
+      return undefined;
     }
+
+    const typeNode = this.variableDeclaration.type ?
+      this.typeChecker.getTypeFromTypeNode(this.variableDeclaration.type) :
+      this.typeChecker.getTypeAtLocation(this.variableDeclaration.initializer!);
+
+    return this.host.typeToString(this.typeChecker, typeNode);
   }
 }

--- a/typescript/src/services/ts-host/host.ts
+++ b/typescript/src/services/ts-host/host.ts
@@ -1,4 +1,4 @@
-import {Declaration} from 'typescript';
+import {Declaration, Type, TypeChecker, TypeFormatFlags} from 'typescript';
 import {getContent} from '../TsParser';
 
 /**
@@ -10,8 +10,14 @@ export class Host {
   /** Whether multiple leading comments for a TypeScript node should be concatenated. */
   concatMultipleLeadingComments: boolean = true;
 
-  getContent(declaration: Declaration) {
+  /** Flags that will be used to format a Type into a string representation. */
+  typeFormatFlags: TypeFormatFlags = TypeFormatFlags.None;
+
+  getContent(declaration: Declaration): string {
     return getContent(declaration, this.concatMultipleLeadingComments);
   }
 
+  typeToString(typeChecker: TypeChecker, type: Type): string {
+    return typeChecker.typeToString(type, undefined, this.typeFormatFlags);
+  }
 }


### PR DESCRIPTION
* Allows developers to specify type format flags in the `Host` class. This is useful if developers want to disable automatic `type` truncation for the `api-doc-types`.

**Note**: This change does only account for `typeToString` conversions in the API doc type classes. The `tsParser` instances are being left untouched.

cc. @petebacondarwin 