### PR TITLE
fix(typescript): use correct optional parameter type

### DIFF
--- a/typescript/mocks/readTypeScriptModules/methodParameters.ts
+++ b/typescript/mocks/readTypeScriptModules/methodParameters.ts
@@ -3,16 +3,18 @@ export class TestClass {
         /** description of param1 */ param1: number,
         /** description of param2 */ param2?: string,
         /** description of param3 */ param3: object = {},
-    ) {
+        /** description of param4 */ param4 = 'default string',
+        ) {
         ///
     }
 
     /**
      * Some description of method 2
-     * @param param3 description of param3
-     * @param param4 description of param4
+     * @param param5 description of param5
+     * @param param6 description of param6
+     * @param param7 description of param7
      */
-    method2(param3: string, param4: number) {
+    method2(param5: string, param6: number, param7 = 42) {
         //
     }
 }

--- a/typescript/src/api-doc-types/ConstExportDoc.ts
+++ b/typescript/src/api-doc-types/ConstExportDoc.ts
@@ -6,24 +6,12 @@ import { ModuleDoc } from './ModuleDoc';
 export class ConstExportDoc extends ExportDoc {
   docType = 'const';
   variableDeclaration = this.declaration as VariableDeclaration;
-  type =  this.getTypeString();
+  type = this.getTypeString(this.declaration);
 
   constructor(host: Host,
               moduleDoc: ModuleDoc,
               symbol: Symbol,
               aliasSymbol?: Symbol) {
     super(host, moduleDoc, symbol, symbol.valueDeclaration!, aliasSymbol);
-  }
-
-  private getTypeString(): string | undefined {
-    if (!this.variableDeclaration.type && !this.variableDeclaration.initializer) {
-      return undefined;
-    }
-
-    const typeNode = this.variableDeclaration.type ?
-      this.typeChecker.getTypeFromTypeNode(this.variableDeclaration.type) :
-      this.typeChecker.getTypeAtLocation(this.variableDeclaration.initializer!);
-
-    return this.host.typeToString(this.typeChecker, typeNode);
   }
 }

--- a/typescript/src/api-doc-types/ParameterDoc.ts
+++ b/typescript/src/api-doc-types/ParameterDoc.ts
@@ -1,5 +1,4 @@
 import { ParameterDeclaration, Symbol } from 'typescript';
-import { getDeclarationTypeText } from '../services/TsParser/getDeclarationTypeText';
 import { nodeToString } from '../services/TsParser/nodeToString';
 import { BaseApiDoc } from './ApiDoc';
 import { ParameterContainer } from './ParameterContainer';
@@ -11,7 +10,7 @@ import { ParameterContainer } from './ParameterContainer';
  */
 export class ParameterDoc extends BaseApiDoc {
   docType = 'parameter';
-  type = getDeclarationTypeText(this.declaration);
+  type = this.getTypeString(this.declaration);
   isOptional = !!(this.declaration.questionToken);
   isRestParam = !!(this.declaration.dotDotDotToken);
   defaultValue = this.declaration.initializer && nodeToString(this.declaration.initializer);

--- a/typescript/src/processors/mergeParameterInfo.spec.ts
+++ b/typescript/src/processors/mergeParameterInfo.spec.ts
@@ -36,14 +36,20 @@ describe('mergeParameterInfo', () => {
     extractTagsProcessor.$process(docsArray);
     mergeParameterInfoProcessor.$process(docsArray);
 
-    const param3: ParameterDoc = docsArray.find(doc => doc.name === 'param3' && doc.container.name === 'method2');
-    expect(param3.id).toEqual('methodParameters/TestClass.method2()~param3');
-    expect(param3.description).toEqual('description of param3');
-    expect(param3.type).toEqual('string');
+    const param5: ParameterDoc = docsArray.find(doc => doc.name === 'param5' && doc.container.name === 'method2');
+    expect(param5.id).toEqual('methodParameters/TestClass.method2()~param5');
+    expect(param5.description).toEqual('description of param5');
+    expect(param5.type).toEqual('string');
 
-    const param4: ParameterDoc = docsArray.find(doc => doc.name === 'param4' && doc.container.name === 'method2');
-    expect(param4.id).toEqual('methodParameters/TestClass.method2()~param4');
-    expect(param4.description).toEqual('description of param4');
-    expect(param4.type).toEqual('number');
+    const param6: ParameterDoc = docsArray.find(doc => doc.name === 'param6' && doc.container.name === 'method2');
+    expect(param6.id).toEqual('methodParameters/TestClass.method2()~param6');
+    expect(param6.description).toEqual('description of param6');
+    expect(param6.type).toEqual('number');
+
+    const param7: ParameterDoc = docsArray.find(doc => doc.name === 'param7' && doc.container.name === 'method2');
+    expect(param7.id).toEqual('methodParameters/TestClass.method2()~param7');
+    expect(param7.description).toEqual('description of param7');
+    expect(param7.type).toEqual('number');
+    expect(param7.defaultValue).toEqual('42');
   });
 });

--- a/typescript/src/processors/readTypeScriptModules/index.spec.ts
+++ b/typescript/src/processors/readTypeScriptModules/index.spec.ts
@@ -300,7 +300,7 @@ describe('readTypeScriptModules', () => {
         processor.$process(docs);
 
         const foo: MethodMemberDoc = docs.find(doc => doc.name === 'foo');
-        expect(foo.parameters).toEqual(['num1: number | string', 'num2?: number']);
+        expect(foo.parameters).toEqual(['num1: string | number', 'num2?: number']);
         const overloads = foo.overloads;
         expect(overloads.map(overload => overload.parameters)).toEqual([
           ['str: string'],
@@ -328,7 +328,7 @@ describe('readTypeScriptModules', () => {
         processor.$process(docs);
 
         const foo: MethodMemberDoc = docs.find(doc => doc.name === 'constructor');
-        expect(foo.parameters).toEqual(['x: string', 'y: number | string', 'z?: number']);
+        expect(foo.parameters).toEqual(['x: string', 'y: string | number', 'z?: number']);
         const overloads = foo.overloads;
         expect(overloads.map(overload => overload.parameters)).toEqual([
           ['x: string', 'y: number'],
@@ -561,8 +561,16 @@ describe('readTypeScriptModules', () => {
         expect(param3.isOptional).toBe(false);
         expect(param3.defaultValue).toBe('{}');
 
+        const param4: ParameterDoc = docs.find(doc => doc.name === 'param4' && doc.container.name === 'method1');
+        expect(param4.docType).toEqual('parameter');
+        expect(param4.id).toEqual('methodParameters/TestClass.method1()~param4');
+        expect(param4.content).toEqual('description of param4');
+        expect(param4.type).toEqual('string');
+        expect(param4.isOptional).toBe(false);
+        expect(param4.defaultValue).toBe('\'default string\'');
+
         const method1: MethodMemberDoc = docs.find(doc => doc.name === 'method1')!;
-        expect(method1.parameterDocs).toEqual([param1, param2, param3]);
+        expect(method1.parameterDocs).toEqual([param1, param2, param3, param4]);
       });
     });
 
@@ -623,13 +631,13 @@ describe('readTypeScriptModules', () => {
       const docs: DocCollection = [];
       processor.$process(docs);
       const functionDoc: FunctionExportDoc = docs.find(doc => doc.docType === 'function');
-      expect(functionDoc.parameters).toEqual(['...args: Array<any>']);
+      expect(functionDoc.parameters).toEqual(['...args: any[]']);
       expect(functionDoc.type).toEqual('void');
 
       const interfaceDoc = docs.find(doc => doc.docType === 'interface');
       expect(interfaceDoc.members.length).toEqual(2);
       const methodDoc: MethodMemberDoc = interfaceDoc.members[0];
-      expect(methodDoc.parameters).toEqual(['...args: Array<any>']);
+      expect(methodDoc.parameters).toEqual(['...args: any[]']);
       expect(methodDoc.type).toEqual('void');
 
       const propertyDoc = interfaceDoc.members[1];

--- a/typescript/src/services/TsParser/getDeclarationTypeText.ts
+++ b/typescript/src/services/TsParser/getDeclarationTypeText.ts
@@ -12,7 +12,7 @@ export function getDeclarationTypeText(declaration: ts.Declaration): string {
     return nodeToString(declaration);
   }
 
-  // if the declaration is being initialized then use the initialization value
+  // if the declaration is being initialized then use the initialization type
   const initializer = getInitializer(declaration);
   if (initializer) {
     if (ts.isNewExpression(initializer)) {


### PR DESCRIPTION
Optional parameters that had not explicit type, but were initialized,
were not having their type computed correctly.

See https://github.com/angular/angular/issues/24355