### PR TITLE
fix vulnerable dependencies

### DIFF
--- a/git/mocks/mocks.js
+++ b/git/mocks/mocks.js
@@ -57,7 +57,7 @@ var mockGitDescribe = {
   stdout: 'v0.10.15'
 };
 
-var mockShellDefault = {
+var mockDefaultFail = {
   code: 1,
   stdout: "default"
 };
@@ -84,5 +84,5 @@ module.exports = {
   mockGitDescribe: mockGitDescribe,
   mockGitLsRemoteTags: mockGitLsRemoteTags,
   mockGitRevParse: mockGitRevParse,
-  mockShellDefault: mockShellDefault
+  mockDefaultFail: mockDefaultFail
 };

--- a/git/services/getPreviousVersions.js
+++ b/git/services/getPreviousVersions.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var shell = require('shelljs');
+var child = require('child_process');
 var _ = require('lodash');
 var semver = require('semver');
 
@@ -15,9 +15,8 @@ module.exports = function getPreviousVersions(decorateVersion, packageInfo) {
     // not contain all commits when cloned with git clone --depth=...
     // Needed e.g. for Travis
     var repo_url = packageInfo.repository.url;
-    var tagResults = shell.exec('git ls-remote --tags ' + repo_url,
-                                {silent: true});
-    if (tagResults.code === 0) {
+    var tagResults = child.spawnSync('git', ['ls-remote', '--tags', repo_url], {encoding: 'utf8'});
+    if (tagResults.status === 0) {
       return _(tagResults.stdout.match(/v[0-9].*[0-9]$/mg))
         .map(function(tag) {
           var version = semver.parse(tag);

--- a/git/services/getPreviousVersions.spec.js
+++ b/git/services/getPreviousVersions.spec.js
@@ -7,10 +7,10 @@ var mocks = require('../mocks/mocks.js');
 var mockPackageFactory = require('../mocks/mockPackage');
 
 describe("getPreviousVersions", function() {
-  var getPreviousVersions, shell;
+  var getPreviousVersions, child;
 
   beforeEach(function() {
-    shell = getPreviousVersionsFactory.__get__('shell');
+    child = getPreviousVersionsFactory.__get__('child');
 
     var mockPackage = mockPackageFactory()
       .factory(getPreviousVersionsFactory);
@@ -22,59 +22,59 @@ describe("getPreviousVersions", function() {
   });
 
   it("should have called exec", function() {
-    spyOn(shell, 'exec').and.returnValue({});
+    spyOn(child, 'spawnSync').and.returnValue({});
     getPreviousVersions();
-    expect(shell.exec).toHaveBeenCalled();
+    expect(child.spawnSync).toHaveBeenCalled();
   });
 
   it("should return an empty list for no tags", function() {
-    spyOn(shell, 'exec').and.returnValue({});
+    spyOn(child, 'spawnSync').and.returnValue({});
     expect(getPreviousVersions()).toEqual([]);
   });
 
   it("should return an array of semvers matching tags", function() {
-    spyOn(shell, 'exec').and.returnValue({
-      code: 0,
+    spyOn(child, 'spawnSync').and.returnValue({
+      status: 0,
       stdout: 'v0.1.1'
     });
     expect(getPreviousVersions()).toEqual([semver('v0.1.1')]);
   });
 
   it("should match v0.1.1-rc1", function() {
-    spyOn(shell, 'exec').and.returnValue({
-      code: 0,
+    spyOn(child, 'spawnSync').and.returnValue({
+      status: 0,
       stdout: 'v0.1.1-rc1'
     });
     expect(getPreviousVersions()).toEqual([semver('v0.1.1-rc1')]);
   });
 
   it("should not match v1.1.1.1", function() {
-    spyOn(shell, 'exec').and.returnValue({
-      code: 0,
+    spyOn(child, 'spawnSync').and.returnValue({
+      status: 0,
       stdout: 'v1.1.1.1'
     });
     expect(getPreviousVersions()).toEqual([]);
   });
 
   it("should not match v1.1.1-rc", function() {
-    spyOn(shell, 'exec').and.returnValue({
-      code: 0,
+    spyOn(child, 'spawnSync').and.returnValue({
+      status: 0,
       stdout: 'v1.1.1-rc'
     });
     expect(getPreviousVersions()).toEqual([]);
   });
 
   it("should match multiple semvers", function() {
-    spyOn(shell, 'exec').and.returnValue({
-      code: 0,
+    spyOn(child, 'spawnSync').and.returnValue({
+      status: 0,
       stdout: 'v0.1.1\nv0.1.2'
     });
     expect(getPreviousVersions()).toEqual([semver('v0.1.1'), semver('v0.1.2')]);
   });
 
   it("should sort multiple semvers", function() {
-    spyOn(shell, 'exec').and.returnValue({
-      code: 0,
+    spyOn(child, 'spawnSync').and.returnValue({
+      status: 0,
       stdout: 'v0.1.1\nv0.1.1-rc1'
     });
     expect(getPreviousVersions()).toEqual([semver('v0.1.1-rc1'), semver('v0.1.1')]);
@@ -84,8 +84,8 @@ describe("getPreviousVersions", function() {
   it("should decorate all versions", function() {
     mocks.decorateVersion.calls.reset();
 
-    spyOn(shell, 'exec').and.returnValue({
-      code: 0,
+    spyOn(child, 'spawnSync').and.returnValue({
+      status: 0,
       stdout: 'v0.1.1\nv0.1.2'
     });
     var versions = getPreviousVersions();

--- a/git/services/versionInfo.js
+++ b/git/services/versionInfo.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var shell = require('shelljs');
+var child = require('child_process');
 var semver = require('semver');
 var _ = require('lodash');
 
@@ -27,7 +27,7 @@ var satisfiesVersion = function(version) {
  * @return {String}         The codename if found, otherwise null/undefined
  */
 var getCodeName = function(tagName) {
-  var gitCatOutput = shell.exec('git cat-file -p ' + tagName, {silent:true}).stdout;
+  var gitCatOutput = child.spawnSync('git', ['cat-file', '-p ' + tagName], {encoding:'utf8'}).stdout;
   var match = gitCatOutput.match(/^.*codename.*$/mg);
   var tagMessage = match && match[0];
   return tagMessage && tagMessage.match(/codename\((.*)\)/)[1];
@@ -38,7 +38,7 @@ var getCodeName = function(tagName) {
  * @return {String} The commit SHA
  */
 function getCommitSHA() {
-  return shell.exec('git rev-parse HEAD', {silent: true}).stdout.replace('\n', '');
+  return child.spawnSync('git', ['rev-parse', 'HEAD'], {encoding:'utf8'}).stdout.replace('\n', '');
 }
 
 /**
@@ -46,7 +46,7 @@ function getCommitSHA() {
  * @return {String} The build segment of the version
  */
 function getBuild() {
-  var hash = shell.exec('git rev-parse --short HEAD', {silent: true}).stdout.replace('\n', '');
+  var hash = child.spawnSync('git', ['rev-parse', '--short', 'HEAD'], {encoding:'utf8'}).stdout.replace('\n', '');
   return 'sha.' + hash;
 }
 
@@ -56,7 +56,7 @@ function getBuild() {
  * @return {SemVer} The version or null
  */
 var getTaggedVersion = function() {
-  var gitTagResult = shell.exec('git describe --exact-match', {silent:true});
+  var gitTagResult = child.spawnSync('git', ['describe', '--exact-match'], {encoding:'utf8'});
 
   if (gitTagResult.code === 0) {
     var tag = gitTagResult.stdout.trim();
@@ -107,7 +107,7 @@ var getSnapshotVersion = function() {
     // last release was a non beta release. Increment the patch level to
     // indicate the next release that we will be doing.
     // E.g. last release was 1.3.0, then the snapshot will be
-    // 1.3.1-build.1, which is lesser than 1.3.1 accorind the semver!
+    // 1.3.1-build.1, which is lesser than 1.3.1 according to semver!
 
     // If the last release was a beta release we don't update the
     // beta number by purpose, as otherwise the semver comparison

--- a/nunjucks/rendering/filters/marked.spec.js
+++ b/nunjucks/rendering/filters/marked.spec.js
@@ -33,8 +33,7 @@ describe("marked custom filter", function() {
         '</ul>\n' +
         '<pre><code>code\n' +
         '  indented code\n' +
-        'code\n' +
-        '</code></pre>\n' +
+        'code</code></pre>\n' +
         ''
       );
   });

--- a/nunjucks/services/renderMarkdown.spec.js
+++ b/nunjucks/services/renderMarkdown.spec.js
@@ -40,8 +40,7 @@ describe("renderMarkdown", function() {
       '<p>some test</p>\n' +
       '<pre><code>code\n' +
       '  indented code\n' +
-      'more code\n' +
-      '</code></pre>\n' +
+      'more code</code></pre>\n' +
       '<p>more text</p>\n'
     );
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "glob": "^7.0.5",
     "htmlparser2": "^3.7.3",
     "lodash": "^4.13.1",
-    "marked": "^0.3.2",
+    "marked": "^0.7.0",
     "minimatch": "^3.0.2",
     "mkdirp": "^0.5.1",
     "mkdirp-promise": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "nunjucks": "^3.1.6",
     "rehype": "^8.0.0",
     "semver": "^5.2.0",
-    "shelljs": "^0.7.0",
     "source-map-support": "^0.4.15",
     "spdx-license-list": "^2.1.0",
     "stringmap": "^0.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1924,7 +1924,7 @@ set-value@^2.0.0:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-shelljs@^0.7.0, shelljs@^0.7.4:
+shelljs@^0.7.4:
   version "0.7.8"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
   integrity sha1-3svPh0sNHl+3LhSxZKloMEjprLM=

--- a/yarn.lock
+++ b/yarn.lock
@@ -1327,10 +1327,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marked@^0.3.2:
-  version "0.3.19"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.19.tgz#5d47f709c4c9fc3c216b6d46127280f40b39d790"
-  integrity sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==
+marked@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
+  integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
 
 micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"


### PR DESCRIPTION
The previous version of `marked` was vulnerable to a
[ReDoS](https://app.snyk.io/vuln/SNYK-JS-MARKED-174116)
attack.

BREAKING CHANGES

There are a few relevant breaking changes with this latest version of `marked`.
This only affects usage of the `renderMarkdown()` service and the `marked`
nunjucks filter. Take a look through the
[marked release notes](https://github.com/markedjs/marked/releases) and
check if this affects you.

Fixes #280