### PR TITLE
fix: fixes the type initialization's

### DIFF
--- a/typescript/mocks/readTypeScriptModules/modules.ts
+++ b/typescript/mocks/readTypeScriptModules/modules.ts
@@ -1,0 +1,3 @@
+export class X<T = any> {
+
+}

--- a/typescript/mocks/tsParser/getDeclarationTypeText.test.ts
+++ b/typescript/mocks/tsParser/getDeclarationTypeText.test.ts
@@ -6,7 +6,7 @@ export function testFunction<T>(param1: T[]): number {
   return 0;
 }
 
-export class TestClass<T> {
+export class TestClass<T = any> {
   prop1: T[];
   prop2 = new OtherClass<T>();
   prop3: OtherClass<T, T> = new OtherClass();

--- a/typescript/src/api-doc-types/ClassLikeExportDoc.ts
+++ b/typescript/src/api-doc-types/ClassLikeExportDoc.ts
@@ -8,6 +8,7 @@ import {
   SymbolFlags,
   symbolName,
   SyntaxKind,
+  SignatureDeclaration,
 } from 'typescript';
 import { Host } from '../services/ts-host/host';
 import { getDecorators, ParsedDecorator } from "../services/TsParser/getDecorators";
@@ -15,6 +16,7 @@ import { getTypeText } from '../services/TsParser/getTypeText';
 
 import { ContainerExportDoc } from './ContainerExportDoc';
 import { ModuleDoc } from './ModuleDoc';
+import { getDeclarationTypeText } from '../services/TsParser/getDeclarationTypeText';
 
 export class HeritageInfo {
   symbol: Symbol | undefined;
@@ -47,7 +49,7 @@ export abstract class ClassLikeExportDoc extends ContainerExportDoc {
       const typeParams: string[] = [];
       this.symbol.members.forEach((member) => {
         if (member.getFlags() & SymbolFlags.TypeParameter) {
-          typeParams.push(symbolName(member));
+          member.declarations.forEach(d => typeParams.push(getDeclarationTypeText(d)));
         }
       });
       if (typeParams.length) return `<${typeParams.join(', ')}>`;

--- a/typescript/src/api-doc-types/ClassLikeExportDoc.ts
+++ b/typescript/src/api-doc-types/ClassLikeExportDoc.ts
@@ -6,17 +6,15 @@ import {
   HeritageClause,
   Symbol,
   SymbolFlags,
-  symbolName,
   SyntaxKind,
-  SignatureDeclaration,
 } from 'typescript';
 import { Host } from '../services/ts-host/host';
+import { getDeclarationTypeText } from '../services/TsParser/getDeclarationTypeText';
 import { getDecorators, ParsedDecorator } from "../services/TsParser/getDecorators";
 import { getTypeText } from '../services/TsParser/getTypeText';
 
 import { ContainerExportDoc } from './ContainerExportDoc';
 import { ModuleDoc } from './ModuleDoc';
-import { getDeclarationTypeText } from '../services/TsParser/getDeclarationTypeText';
 
 export class HeritageInfo {
   symbol: Symbol | undefined;

--- a/typescript/src/processors/readTypeScriptModules/index.spec.ts
+++ b/typescript/src/processors/readTypeScriptModules/index.spec.ts
@@ -264,6 +264,17 @@ describe('readTypeScriptModules', () => {
     });
   });
 
+  describe('modules', () => {
+    it('should include class type parameters', () => {
+      processor.sourceFiles = [ 'modules.ts'];
+      const docs: DocCollection = [];
+      processor.$process(docs);
+      const typeAliasDoc = docs[1];
+      expect(typeAliasDoc.docType).toEqual('class');
+      expect(typeAliasDoc.typeParams).toEqual('<T = any>');
+    });
+  })
+
   describe('exported functions', () => {
     it('should include type parameters', () => {
       processor.sourceFiles = [ 'functions.ts'];

--- a/typescript/src/services/TsParser/getDeclarationTypeText.spec.ts
+++ b/typescript/src/services/TsParser/getDeclarationTypeText.spec.ts
@@ -23,10 +23,12 @@ describe('getDeclarationTypeText', () => {
     expect(getDeclarationTypeText(testFunction.typeParameters![0])).toEqual('T');
 
     const testClass = getExport('TestClass');
+    const testClassDeclaration = testClass.getDeclarations()![0] as SignatureDeclaration;
     expect(getDeclarationTypeText(testClass.members!.get('prop1' as __String)!.getDeclarations()![0])).toEqual('T[]');
     expect(getDeclarationTypeText(testClass.members!.get('prop2' as __String)!.getDeclarations()![0])).toEqual('OtherClass<T>');
     expect(getDeclarationTypeText(testClass.members!.get('prop3' as __String)!.getDeclarations()![0])).toEqual('OtherClass<T, T>');
     expect(getDeclarationTypeText(testClass.members!.get('method'as __String)!.getDeclarations()![0])).toEqual('T');
+    expect(getDeclarationTypeText(testClassDeclaration.typeParameters![0])).toEqual('T = any');
 
     function getExport(name: string) {
       return moduleExports.find(e => e.name === name)!;


### PR DESCRIPTION
Previously, the type initializations in a class declaration were
removed when the docs are generated. This fixes this issue.