### PR TITLE
feat(jsdoc): add support for version tag

### DIFF
--- a/jsdoc/tag-defs/index.js
+++ b/jsdoc/tag-defs/index.js
@@ -30,5 +30,6 @@ module.exports = [
   require('./see'),
   require('./since'),
   require('./type'),
-  require('./usage')
+  require('./usage'),
+  require('./version')
 ];

--- a/jsdoc/tag-defs/index.spec.js
+++ b/jsdoc/tag-defs/index.spec.js
@@ -3,7 +3,7 @@ const tagDefFactories = require('./');
 describe("jsdoc tagdefs", () => {
   it("should contain an array of tagDef factory functions", () => {
     expect(tagDefFactories).toEqual(jasmine.any(Array));
-    expect(tagDefFactories.length).toEqual(31);
+    expect(tagDefFactories.length).toEqual(32);
     tagDefFactories.forEach(factory => expect(factory).toEqual(jasmine.any(Function)));
   });
 });

--- a/jsdoc/tag-defs/version.js
+++ b/jsdoc/tag-defs/version.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return { name: 'version' };
+};


### PR DESCRIPTION
Add support for jsdoc [@version tag](https://jsdoc.app/tags-version.html),