### PR TITLE
Update ecmaVersion to 8

### DIFF
--- a/jsdoc/services/jsParser-config.js
+++ b/jsdoc/services/jsParser-config.js
@@ -15,7 +15,7 @@ module.exports = function jsParserConfig() {
 
       // Set to 3, 5 (default), 6, 7, 8, 9, 10, 11, or 12 to specify the version of ECMAScript syntax you want to use.
       // You can also set to 2015 (same as 6), 2016 (same as 7), 2017 (same as 8), 2018 (same as 9), 2019 (same as 10), 2020 (same as 11), or 2021 (same as 12) to use the year-based naming.
-      ecmaVersion: 6,
+      ecmaVersion: 8,
 
       // specify which type of script you're parsing ("script" or "module")
       sourceType: "script",

--- a/jsdoc/services/jsParser-config.spec.js
+++ b/jsdoc/services/jsParser-config.spec.js
@@ -16,6 +16,6 @@ describe('jsParserConfig service', function() {
     expect(jsParserConfig.loc).toBe(true);
     expect(jsParserConfig.range).toBe(true);
     expect(jsParserConfig.tokens).toBe(true);
-    expect(jsParserConfig.ecmaVersion).toBe(6);
+    expect(jsParserConfig.ecmaVersion).toBe(8);
   });
 });


### PR DESCRIPTION
This would allow the usage of additional stuff such as the - nowadays widespread - async keyword.

I verified this in a local setup.

#312