### PR TITLE
fix(ngdoc/link filter): correctly handle missing title

### DIFF
--- a/ngdoc/rendering/filters/link.js
+++ b/ngdoc/rendering/filters/link.js
@@ -2,7 +2,7 @@ module.exports = function() {
   return {
     name: 'link',
     process(url, title, doc) {
-      return `{@link ${url} ${title} }`;
+      return `{@link ${url} ${title || ''} }`;
     }
   };
 };

--- a/ngdoc/rendering/filters/link.spec.js
+++ b/ngdoc/rendering/filters/link.spec.js
@@ -15,4 +15,8 @@ describe("link filter", () => {
     expect(filter.process('URL', 'TITLE')).toEqual('{@link URL TITLE }');
   });
 
+  it("should omit title when it is undefined", () => {
+    expect(filter.process('URL', undefined)).toEqual('{@link URL  }');
+  });
+
 });


### PR DESCRIPTION
Previously, when the `title` argument passed to the `link` filter was `undefined`, it would be stringified and included in the returned `@link` annotation (for example, `'{@link some/url undefined }'`). This would result in the string `'undefined'` being used as the link's text: `<a href="some/url">undefined</a>`.

This commit fixes the `link` filter behavior to omit the `title` when it is `undefined`. This results in `@link` annotations that do not include a "title" part (for example, `{@link some/url  }`), which in turn allows the link text to be inferred based on the URL.

NOTE:
This was accidentally broken in [commit 32d3b9bcd][1] by switching from lodash's `_.template()` (which treats undefined properties as empty strings) to a template literal (which stringifies undefined arguments).

[1]: https://github.com/angular/dgeni-packages/commit/32d3b9bcd528ab8b31a8bebd491ccc707656719e#diff-32bddedc9842809bfa764178ccf14e3e7bba74df4c5635224212eecbc2c52fceR5