### PR TITLE
build(deps): update `typescript` to v4.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "semver": "^5.2.0",
     "source-map-support": "^0.4.15",
     "spdx-license-list": "^2.1.0",
-    "typescript": "~3.2.2",
+    "typescript": "~4.5.4",
     "urlencode": "^1.1.0"
   },
   "devDependencies": {

--- a/post-process-html/src/processors/postProcessHtml.ts
+++ b/post-process-html/src/processors/postProcessHtml.ts
@@ -45,7 +45,8 @@ export class PostProcessHtml implements Processor {
           );
           doc.vFile = vFile;
         } catch (e) {
-          throw new Error(this.createDocMessage(e.message, doc));
+          const errorMessage = (e instanceof Error) ? e.message : `${e}`;
+          throw new Error(this.createDocMessage(errorMessage, doc));
         }
       });
   }

--- a/typescript/mocks/readTypeScriptModules/imports.ts
+++ b/typescript/mocks/readTypeScriptModules/imports.ts
@@ -1,0 +1,3 @@
+import { X } from './modules';
+
+export const Y = !X;

--- a/typescript/src/api-doc-types/ClassLikeExportDoc.ts
+++ b/typescript/src/api-doc-types/ClassLikeExportDoc.ts
@@ -47,7 +47,7 @@ export abstract class ClassLikeExportDoc extends ContainerExportDoc {
       const typeParams: string[] = [];
       this.symbol.members.forEach((member) => {
         if (member.getFlags() & SymbolFlags.TypeParameter) {
-          member.declarations.forEach(d => typeParams.push(getDeclarationTypeText(d)));
+          member.declarations?.forEach(d => typeParams.push(getDeclarationTypeText(d)));
         }
       });
       if (typeParams.length) return `<${typeParams.join(', ')}>`;

--- a/typescript/src/api-doc-types/ModuleDoc.ts
+++ b/typescript/src/api-doc-types/ModuleDoc.ts
@@ -1,4 +1,6 @@
 import { Declaration, TypeChecker } from 'typescript';
+import * as path from 'canonical-path';
+
 import { ModuleSymbol } from '../services/TsParser';
 import { FileInfo } from '../services/TsParser/FileInfo';
 
@@ -11,7 +13,7 @@ import { ExportDoc } from './ExportDoc';
  */
 export class ModuleDoc implements ApiDoc {
   docType = 'module';
-  id = this.symbol.name.replace(/^"|"$/g, '').replace(/\/index$/, '');
+  id = ensureRelative(this.basePath, this.symbol.name.replace(/^"|"$/g, '').replace(/\/index$/, ''));
   name = this.id.split('/').pop()!;
   declaration: Declaration = this.symbol.valueDeclaration!;
   aliases = [this.id, this.name];
@@ -27,4 +29,15 @@ export class ModuleDoc implements ApiDoc {
               public basePath: string,
               public hidePrivateMembers: boolean,
               public typeChecker: TypeChecker) {}
+}
+
+/**
+ * Convert a potentially absolute path to relative.
+ *
+ * If `toPath` is already relative, it is practically returned unchanged. If it is an absolute path,
+ * it is resolved relative to `fromPath` (which should always be an absolute path).
+ */
+function ensureRelative(absoluteFromPath: string, toPath: string): string {
+  const absoluteToPath = path.resolve(absoluteFromPath, toPath);
+  return path.relative(absoluteFromPath, absoluteToPath);
 }

--- a/typescript/src/processors/readTypeScriptModules/index.spec.ts
+++ b/typescript/src/processors/readTypeScriptModules/index.spec.ts
@@ -273,7 +273,16 @@ describe('readTypeScriptModules', () => {
       expect(typeAliasDoc.docType).toEqual('class');
       expect(typeAliasDoc.typeParams).toEqual('<T = any>');
     });
-  })
+
+    it('should correctly compute doc IDs for imported modules', () => {
+      // NOTE: The order of files is important here. We want `modules.ts` to be first discovered by
+      //       TypeScript as an import in `imports.ts`, therefore, `imports.ts` has to come first.
+      processor.sourceFiles = ['imports.ts', 'modules.ts'];
+      const docs: DocCollection = [];
+      processor.$process(docs);
+      expect(docs.map(d => d.id)).toEqual(['imports', 'imports/Y', 'modules', 'modules/X']);
+    });
+  });
 
   describe('exported functions', () => {
     it('should include type parameters', () => {

--- a/typescript/src/services/TsParser/CustomCompilerHost.spec.ts
+++ b/typescript/src/services/TsParser/CustomCompilerHost.spec.ts
@@ -20,36 +20,36 @@ describe('CustomCompilerHost', () => {
   });
 
   describe('getSourceFile', () => {
-    it('should return a SourceFile object for a given path', () => {
+    it('should return a SourceFile object for a given relative path', () => {
       const sourceFile = host.getSourceFile('testSrc.ts', 0)!;
-      expect(sourceFile.fileName).toEqual('testSrc.ts');
+      expect(sourceFile.fileName).toEqual(resolve(baseDir, 'testSrc.ts'));
       expect(sourceFile.pos).toEqual(0);
       expect(sourceFile.text).toEqual(jasmine.any(String));
     });
 
-    it('should return a SourceFile object for a given path, with fileName relative to baseDir', () => {
+    it('should return a SourceFile object for a given absolute path', () => {
       const sourceFile = host.getSourceFile(resolve(baseDir, 'testSrc.ts'), 0)!;
-      expect(sourceFile.fileName).toEqual('testSrc.ts');
+      expect(sourceFile.fileName).toEqual(resolve(baseDir, 'testSrc.ts'));
       expect(sourceFile.pos).toEqual(0);
       expect(sourceFile.text).toEqual(jasmine.any(String));
     });
 
     it('should try each of the configured extensions and update the filename to the correct extension', () => {
       let sourceFile = host.getSourceFile('testSrc.js', 0)!;
-      expect(sourceFile.fileName).toEqual('testSrc.ts');
+      expect(sourceFile.fileName).toEqual(resolve(baseDir, 'testSrc.ts'));
 
       sourceFile = host.getSourceFile('../mockPackage.ts', 0)!;
-      expect(sourceFile.fileName).toEqual('../mockPackage.js');
+      expect(sourceFile.fileName).toEqual(resolve(baseDir, '../mockPackage.js'));
     });
 
     it('should cope with folders with names that look like source files', () => {
       const sourceFile = host.getSourceFile('zone.js', 0)!;
-      expect(sourceFile.fileName).toEqual('zone.js/index.ts');
+      expect(sourceFile.fileName).toEqual(resolve(baseDir, 'zone.js/index.ts'));
     });
 
     it('should cope with "invalid" relative references to node_modules, which are actually outside the baseDir', () => {
       const sourceFile = host.getSourceFile('node_modules/@types/jasmine/index.d.ts', 0)!;
-      expect(sourceFile.fileName).toEqual('../../../node_modules/@types/jasmine/index.d.ts');
+      expect(sourceFile.fileName).toEqual(resolve(baseDir, '../../../node_modules/@types/jasmine/index.d.ts'));
     });
   });
 

--- a/typescript/src/services/TsParser/CustomCompilerHost.ts
+++ b/typescript/src/services/TsParser/CustomCompilerHost.ts
@@ -23,7 +23,7 @@ export class CustomCompilerHost implements CompilerHost {
       return createSourceFile(path.relative(this.baseDir, resolvedPath), text, languageVersion);
     } catch (e) {
       // if it is a folder then try loading the index file of that folder
-      if (e.code === 'EISDIR') {
+      if ((e as NodeJS.ErrnoException).code === 'EISDIR') {
         return this.getSourceFile(fileName + '/index.ts', languageVersion, onError);
       }
       // otherwise ignore the error and move on to the strategy below...
@@ -69,9 +69,10 @@ export class CustomCompilerHost implements CompilerHost {
         return createSourceFile(baseFilePath + extension, text, languageVersion);
       } catch (e) {
         // Try again if the file simply did not exist, otherwise report the error as a warning
-        if (e.code !== 'ENOENT') {
-          if (onError) onError(e.message);
-          this.log.warn('Error reading ' + resolvedPathWithExt + ' : ' + e.message);
+        if ((e as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+          const errorMessage = (e instanceof Error) ? e.message : `${e}`;
+          if (onError) onError(errorMessage);
+          this.log.warn('Error reading ' + resolvedPathWithExt + ' : ' + errorMessage);
         }
       }
     }

--- a/typescript/src/services/TsParser/FileInfo.ts
+++ b/typescript/src/services/TsParser/FileInfo.ts
@@ -7,12 +7,12 @@ const path = require('canonical-path');
  * The file (and the location in the file) from where an API doc element was sourced.
  */
 export class FileInfo {
-  relativePath = this.declaration.getSourceFile().fileName;
   location = new Location(this.declaration);
-  filePath = path.resolve(this.basePath, this.relativePath);
+  filePath = path.resolve(this.basePath, this.declaration.getSourceFile().fileName);
   baseName = path.basename(this.filePath, path.extname(this.filePath));
   extension = path.extname(this.filePath).replace(/^\./, '');
-  projectRelativePath = path.relative(this.basePath, this.filePath);
+  relativePath = path.relative(this.basePath, this.filePath);
+  projectRelativePath = this.relativePath;
   realFilePath = this.getRealFilePath(this.filePath);
   realProjectRelativePath = path.relative(this.basePath, this.realFilePath);
 

--- a/typescript/src/services/TsParser/index.ts
+++ b/typescript/src/services/TsParser/index.ts
@@ -2,9 +2,6 @@
 import { CompilerOptions, createProgram, NewLineKind, Program, Symbol, SymbolFlags, TypeChecker } from 'typescript';
 import { CustomCompilerHost } from './CustomCompilerHost';
 
-// This import lacks type definitions.
-const path = require('canonical-path');
-
 export { getExportDocType } from './getExportDocType';
 export { getContent } from './getContent';
 export { getAccessibility } from './getAccessibility';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2218,10 +2218,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@~3.2.2:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
-  integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
+typescript@~4.5.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
+  integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
 
 unified@^7.0.0:
   version "7.1.0"


### PR DESCRIPTION
This PR updates the `typescript` dependency to v4.5.4 (to take advantage of newer features and fix issues such as angular/angular#44468). See the individual commits for details.

##
This is a prerequisite for fixing angular/angular#44468.