### PR TITLE
fix(jsdoc): runtime error when jsdoc uses unknown tag definition

### DIFF
--- a/jsdoc/processors/extract-tags.js
+++ b/jsdoc/processors/extract-tags.js
@@ -195,7 +195,13 @@ module.exports = function extractTagsProcessor(log, parseTagsProcessor, createDo
       }
 
       message += 'Line: ' + badTag.startingLine + ': @' + badTag.tagName + ' ' + description + '\n';
-      badTag.errors.forEach(error => message += '    * ' + error + '\n');
+
+      // An object of type `Tag` in the `badTags` list does not necessarily have an `errors`
+      // field attached. This can happen when the tag does not have a tag definition at all.
+      // We only append more specific error messages if such concrete errors are available.
+      if (badTag.errors !== undefined) {
+        badTag.errors.forEach(error => message += '    * ' + error + '\n');
+      }
     });
 
     return message + '\n';

--- a/jsdoc/processors/extract-tags.spec.js
+++ b/jsdoc/processors/extract-tags.spec.js
@@ -46,6 +46,17 @@ describe("extractTagsProcessor", () => {
         '    * second bad thing\n\n');
   });
 
+  it("should log a warning if the doc contains bad tags (no known tag definition)", () => {
+    const doc = createDoc([]);
+    const tag = new Tag(/* tagDef */ undefined, 'notKnown', 'desc', /* lineNumber */ 3);
+
+    doc.tags.badTags = [tag];
+
+    processor.$process([doc]);
+    expect(mockLog.warn).toHaveBeenCalledWith('Invalid tags found - doc\n' +
+      'Line: 3: @notKnown desc...\n\n');
+});
+
   describe('default tag-def', () => {
     it("should the extract the description property to a property with the name of the tagDef", () => {
       const tagDef = { name: 'a' };


### PR DESCRIPTION
Dgeni packages JSDoc does not support `@throws` by default (surprisingly
as a side note). Now if a project like Angular Material uses that somewhere,
the `Tag` will be instantiated without a `tagDef` because there is none.

Later after parsing (when the `Tag` was created), the extract tags processor
will log an error for such tags. This logic does not work as expected currently
because such `Tag` instances do not necessarily have the `errors` field, resulting
in runtime exceptions like:

```js
TypeError: Error running processor "extractTagsProcessor":
Cannot read properties of undefined (reading 'forEach')
    at /private/var/tmp/_bazel_paul/24d3819ba30ba6e17ef227c181228208/sandbox/darwin-sandbox/4/execroot/angular_material/bazel-out/host/bin/tools/dgeni/dgeni.sh.runfiles/npm/node_modules/dgeni-packages/jsdoc/processors/extract-tags.js:198:21
    at Array.forEach (<anonymous>)
    at formatBadTagErrorMessage (/private/var/tmp/_bazel_paul/24d3819ba30ba6e17ef227c181228208/sandbox/darwin-sandbox/4/execroot/angular_material/bazel-out/host/bin/tools/dgeni/dgeni.sh.runfiles/npm/node_modules/dgeni-packages/jsdoc/processors/extract-tags.js:188:22)
    at tagExtractor (/private/var/tmp/_bazel_paul/24d3819ba30ba6e17ef227c181228208/sandbox/darwin-sandbox/4/execroot/angular_material/bazel-out/host/bin/tools/dgeni/dgeni.sh.runfiles/npm/node_modules/dgeni-packages/jsdoc/processors/extract-tags.js:92:18)
```

This commit fixes that runtime error. It seems like this error has been introduced
as a side-effect of switching away from Lodash to actual `tag.errors.forEach`.

Interestingly before this change, tags like `@throws` were just processed as is silently
and no warning/error was printed at all.