### PR TITLE
fix(typescript): account for breaking change in TypeScript 4.8

### DIFF
--- a/typescript/src/services/TsParser/getDecorators.ts
+++ b/typescript/src/services/TsParser/getDecorators.ts
@@ -5,8 +5,8 @@ import {
     Decorator,
     EmitHint,
     Expression,
+    isDecorator,
     NodeArray,
-    ObjectLiteralElement,
     ObjectLiteralElementLike,
     ObjectLiteralExpression,
     PropertyAssignment,
@@ -26,8 +26,12 @@ export interface ParsedDecorator {
 }
 
 export function getDecorators(declaration: Declaration) {
-  if (declaration.decorators) {
-    return declaration.decorators.map<ParsedDecorator>(decorator => {
+  const decorators = declaration.decorators ||
+    // As of TypeScript 4.8 the decorators are part of the `modifiers` array.
+    declaration.modifiers?.filter(isDecorator) as unknown as Decorator[]|undefined;
+
+  if (decorators?.length) {
+    return decorators.map<ParsedDecorator>(decorator => {
       const callExpression = getCallExpression(decorator);
       if (callExpression) {
         return {


### PR DESCRIPTION
In TypeScript 4.8 the node's decorators are inside the `modifiers` array, instead of in a separate `decorators` array. These changes add some code to account for the difference while maintaining backwards compatibility.